### PR TITLE
Add visible Showcase test contribution

### DIFF
--- a/showcase/test-showcase-contribution/README.md
+++ b/showcase/test-showcase-contribution/README.md
@@ -1,0 +1,20 @@
+# Test Showcase Contribution
+
+This hidden package is a reference contribution for testing the EconomyOS
+Showcase submission flow. It is intentionally marked `hidden: true` in
+`showcase.json`, so the docs sync validates the package but does not publish it
+as a public Showcase card.
+
+Use this folder to verify the expected contribution shape:
+
+- `showcase.json` contains card-ready metadata, public proof links, artifacts,
+  feedback prompts, and the nested skill source path.
+- `soul.md` contains optional public agent context.
+- `skills/showcase-test-contribution/SKILL.md` demonstrates a project-specific
+  skill committed inside the showcase package.
+- `examples/proof.md` stands in for a public proof artifact.
+
+For real submissions, replace the placeholder package text with concrete proof
+from an actual EconomyOS workflow. An X video is highly recommended when
+available, but screenshots, hosted video, live pages, interactive demos, public
+PRs, demo repos, traces, and redacted result reports are also valid proof.

--- a/showcase/test-showcase-contribution/README.md
+++ b/showcase/test-showcase-contribution/README.md
@@ -1,9 +1,8 @@
 # Test Showcase Contribution
 
-This hidden package is a reference contribution for testing the EconomyOS
-Showcase submission flow. It is intentionally marked `hidden: true` in
-`showcase.json`, so the docs sync validates the package but does not publish it
-as a public Showcase card.
+This package is a reference contribution for testing the EconomyOS Showcase
+submission flow. It is visible by default, so the docs sync validates the
+package and publishes it as a public Showcase card.
 
 Use this folder to verify the expected contribution shape:
 

--- a/showcase/test-showcase-contribution/examples/proof.md
+++ b/showcase/test-showcase-contribution/examples/proof.md
@@ -1,0 +1,18 @@
+# Test Proof Note
+
+This proof note is a placeholder artifact for the hidden test contribution. It
+exists to exercise the Showcase contribution shape without representing a live
+workflow.
+
+For a real Showcase submission, this file should be replaced with proof that a
+reviewer can inspect, such as:
+
+- X video or hosted video.
+- Screenshot or image sequence.
+- Live page or interactive demo.
+- Public PR or demo repo.
+- Redacted result report, trace, receipt state, dashboard state, or API
+  response.
+
+No secrets, card details, account records, wallet material, magic links, OTPs,
+or private prompts should be published.

--- a/showcase/test-showcase-contribution/showcase.json
+++ b/showcase/test-showcase-contribution/showcase.json
@@ -1,10 +1,9 @@
 {
   "slug": "test-showcase-contribution",
-  "hidden": true,
   "title": "Test Showcase Contribution",
-  "tagline": "A hidden reference package that exercises the EconomyOS Showcase contribution shape.",
+  "tagline": "A reference package that exercises the EconomyOS Showcase contribution shape.",
   "description": "This package demonstrates how a builder can submit card metadata, proof links, optional soul.md context, and a project-specific reusable skill in one acp-cli-demos PR.",
-  "status": "hidden test",
+  "status": "visible test",
   "topic": "skills",
   "topics": ["skills", "identity"],
   "builder": {
@@ -19,7 +18,7 @@
   },
   "primitives": ["email", "card"],
   "visual": {
-    "kind": "hidden proof package",
+    "kind": "proof package",
     "eyebrow": "reference package",
     "title": "showcase contribution"
   },
@@ -28,7 +27,7 @@
       "name": "showcase-test-contribution",
       "href": "https://github.com/Virtual-Protocol/acp-cli-demos/tree/main/showcase/test-showcase-contribution/skills/showcase-test-contribution",
       "sourcePath": "showcase/test-showcase-contribution/skills/showcase-test-contribution",
-      "summary": "Reference workflow for assembling and validating a hidden EconomyOS Showcase test package.",
+      "summary": "Reference workflow for assembling and validating an EconomyOS Showcase test package.",
       "install": "cp -R showcase/test-showcase-contribution/skills/showcase-test-contribution ~/.agents/skills/\ncp -R showcase/test-showcase-contribution/skills/showcase-test-contribution ~/.claude/skills/"
     }
   ],
@@ -51,7 +50,7 @@
   ],
   "soul": {
     "href": "https://github.com/Virtual-Protocol/acp-cli-demos/blob/main/showcase/test-showcase-contribution/soul.md",
-    "summary": "Optional public context for the hidden test agent, including role, boundaries, and proof preferences."
+    "summary": "Optional public context for the test agent, including role, boundaries, and proof preferences."
   },
   "feedbackPrompts": [
     "Does the package make the contribution flow clear?",

--- a/showcase/test-showcase-contribution/showcase.json
+++ b/showcase/test-showcase-contribution/showcase.json
@@ -1,0 +1,61 @@
+{
+  "slug": "test-showcase-contribution",
+  "hidden": true,
+  "title": "Test Showcase Contribution",
+  "tagline": "A hidden reference package that exercises the EconomyOS Showcase contribution shape.",
+  "description": "This package demonstrates how a builder can submit card metadata, proof links, optional soul.md context, and a project-specific reusable skill in one acp-cli-demos PR.",
+  "status": "hidden test",
+  "topic": "skills",
+  "topics": ["skills", "identity"],
+  "builder": {
+    "name": "Virtuals Protocol",
+    "url": "https://github.com/Virtual-Protocol"
+  },
+  "links": {
+    "repo": "https://github.com/Virtual-Protocol/acp-cli-demos/tree/main/showcase/test-showcase-contribution",
+    "demo": "https://github.com/Virtual-Protocol/acp-cli-demos/blob/main/showcase/test-showcase-contribution/examples/proof.md",
+    "share": "https://github.com/Virtual-Protocol/acp-cli-demos/tree/main/showcase/test-showcase-contribution",
+    "feedback": "https://github.com/Virtual-Protocol/acp-cli-demos/issues/new?title=Feedback%3A%20Test%20Showcase%20Contribution&body=Which%20feedback%20prompt%20fits%3F%0A%0A-%20The%20package%20shape%20is%20clear%0A-%20The%20proof%20options%20need%20more%20examples%0A-%20The%20soul.md%20guidance%20needs%20more%20redaction%20detail%0A%0ANotes%3A%0A"
+  },
+  "primitives": ["email", "card"],
+  "visual": {
+    "kind": "hidden proof package",
+    "eyebrow": "reference package",
+    "title": "showcase contribution"
+  },
+  "skills": [
+    {
+      "name": "showcase-test-contribution",
+      "href": "https://github.com/Virtual-Protocol/acp-cli-demos/tree/main/showcase/test-showcase-contribution/skills/showcase-test-contribution",
+      "sourcePath": "showcase/test-showcase-contribution/skills/showcase-test-contribution",
+      "summary": "Reference workflow for assembling and validating a hidden EconomyOS Showcase test package.",
+      "install": "cp -R showcase/test-showcase-contribution/skills/showcase-test-contribution ~/.agents/skills/\ncp -R showcase/test-showcase-contribution/skills/showcase-test-contribution ~/.claude/skills/"
+    }
+  ],
+  "artifacts": [
+    {
+      "label": "Package README",
+      "href": "https://github.com/Virtual-Protocol/acp-cli-demos/blob/main/showcase/test-showcase-contribution/README.md",
+      "kind": "docs"
+    },
+    {
+      "label": "Test proof note",
+      "href": "https://github.com/Virtual-Protocol/acp-cli-demos/blob/main/showcase/test-showcase-contribution/examples/proof.md",
+      "kind": "proof"
+    },
+    {
+      "label": "Skill source",
+      "href": "https://github.com/Virtual-Protocol/acp-cli-demos/tree/main/showcase/test-showcase-contribution/skills/showcase-test-contribution",
+      "kind": "skill"
+    }
+  ],
+  "soul": {
+    "href": "https://github.com/Virtual-Protocol/acp-cli-demos/blob/main/showcase/test-showcase-contribution/soul.md",
+    "summary": "Optional public context for the hidden test agent, including role, boundaries, and proof preferences."
+  },
+  "feedbackPrompts": [
+    "Does the package make the contribution flow clear?",
+    "Which proof option should this example show next?",
+    "Is the optional soul.md guidance specific enough?"
+  ]
+}

--- a/showcase/test-showcase-contribution/skills/showcase-test-contribution/SKILL.md
+++ b/showcase/test-showcase-contribution/skills/showcase-test-contribution/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: showcase-test-contribution
+description: Assemble and validate a hidden EconomyOS Showcase test contribution package.
+version: 0.1.0
+---
+
+# Showcase Test Contribution
+
+Use this skill when testing whether a Showcase package contains the expected
+metadata, proof links, optional public agent context, and reusable workflow
+instructions before a contributor opens a PR.
+
+## Inputs
+
+- Project title, tagline, description, builder name, and builder URL.
+- Public proof artifact, preferably an X video when available.
+- EconomyOS primitives used by the project.
+- Optional public `soul.md` content.
+- Redaction notes for any live workflow evidence.
+
+## Workflow
+
+1. Confirm the project is a real EconomyOS workflow, not only an idea.
+2. Check that the proof artifact is inspectable by reviewers.
+3. Create or update `showcase/<project-slug>/showcase.json`.
+4. Add `soul.md` only if the builder wants to publish public agent context.
+5. Add reusable workflow instructions under
+   `showcase/<project-slug>/skills/<skill-name>/SKILL.md` when the workflow can
+   be repeated.
+6. Run `node scripts/validate-showcase.mjs`.
+
+## Approval Gates
+
+Stop for explicit approval before spending money, creating accounts, posting
+publicly, deploying production changes, or exposing private operational context.
+
+## Stop Conditions
+
+- Public proof is missing.
+- Required manifest fields are incomplete.
+- The skill source path does not contain `SKILL.md`.
+- Any artifact includes secrets, credentials, wallet material, card details, or
+  private account records.
+
+## Output
+
+Return the changed package path, validator result, and any fields still needing
+maintainer review.

--- a/showcase/test-showcase-contribution/soul.md
+++ b/showcase/test-showcase-contribution/soul.md
@@ -1,0 +1,24 @@
+# Test Showcase Agent Soul
+
+This is optional public agent context for the hidden Showcase test package.
+
+## Role
+
+The agent helps a builder assemble a complete EconomyOS Showcase package from a
+real project, including proof, metadata, reusable skill notes, and redaction
+checks.
+
+## Boundaries
+
+- It does not perform payments, production mutations, public posting, or account
+  creation without explicit approval.
+- It does not publish private prompts, credentials, wallet material, account
+  records, card details, magic links, or operational secrets.
+- It treats `showcase.json` as the publishing manifest and `soul.md` as optional
+  public context.
+
+## Review Preference
+
+The agent prefers concrete proof over claims. X videos are highly recommended
+for public distribution, but any inspectable artifact that proves the workflow
+ran is acceptable.


### PR DESCRIPTION
## Summary
- Add a visible `showcase/test-showcase-contribution` package based on the public Showcase contribution flow at https://os.virtuals.io/community/showcase-contribute.
- Include a complete `showcase.json`, package README, optional `soul.md`, proof note, and nested project-specific skill.
- Leave the manifest visible so docs sync publishes it as a public Showcase card after merge.

## Tests
- `node scripts/validate-showcase.mjs` -> validated 2 Showcase manifests.
- `ACP_CLI_DEMOS_DIR=/Users/celesteanglm/code/virtuals_protocol/acp-cli-demos npm run sync:showcase` -> synced 2 public Showcase projects.
- `VITE_ENABLE_COMMUNITY_SHOWCASE=true npm run build` in `whitepaper-economyOS`.