### PR TITLE
Explain missing Showcase sync token

### DIFF
--- a/.github/workflows/dispatch-showcase-sync.yml
+++ b/.github/workflows/dispatch-showcase-sync.yml
@@ -17,6 +17,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Check docs sync token
+        shell: bash
+        env:
+          SHOWCASE_SYNC_TOKEN: ${{ secrets.SHOWCASE_SYNC_TOKEN }}
+        run: |
+          if [[ -z "$SHOWCASE_SYNC_TOKEN" ]]; then
+            echo "::error title=Missing SHOWCASE_SYNC_TOKEN::Set the SHOWCASE_SYNC_TOKEN repository secret in Virtual-Protocol/acp-cli-demos. It must be a GitHub token that can create repository_dispatch events in Virtual-Protocol/whitepaper-economyOS."
+            exit 1
+          fi
+
       - name: Trigger EconomyOS docs showcase sync
         uses: peter-evans/repository-dispatch@v3
         with:

--- a/README.md
+++ b/README.md
@@ -30,8 +30,11 @@ After a Showcase PR is approved and merged to `main`, changes under
 `showcase/**` dispatch the EconomyOS docs sync. The docs workflow
 regenerates the Showcase page data from the accepted manifest.
 
-Automation requirement: configure `SHOWCASE_SYNC_TOKEN` in this repo with
-permission to dispatch workflows in `Virtual-Protocol/whitepaper-economyOS`.
+Automation requirement: configure `SHOWCASE_SYNC_TOKEN` in this repo with a
+GitHub token that can create `repository_dispatch` events in
+`Virtual-Protocol/whitepaper-economyOS`. If the secret is missing, the dispatch
+workflow cannot authenticate and GitHub Actions will fail before the docs sync
+starts.
 
 Validate manifests before requesting review:
 

--- a/showcase/README.md
+++ b/showcase/README.md
@@ -23,7 +23,8 @@ the docs site.
 
 The publish step requires the `SHOWCASE_SYNC_TOKEN` repository secret to be set
 in `acp-cli-demos`. It should be a GitHub token that can create a repository
-dispatch event in `Virtual-Protocol/whitepaper-economyOS`.
+dispatch event in `Virtual-Protocol/whitepaper-economyOS`. Without this secret,
+the dispatch action receives no auth token and fails before the docs sync starts.
 
 ## Required Shape
 


### PR DESCRIPTION
## Summary
- Add a preflight check before the cross-repo repository dispatch step.
- Fail with an explicit `SHOWCASE_SYNC_TOKEN` error instead of the generic `Parameter token or opts.auth is required` message.
- Clarify in README docs that `acp-cli-demos` needs a token able to create `repository_dispatch` events in `whitepaper-economyOS`.

## Tests
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/dispatch-showcase-sync.yml'); puts 'workflow yaml ok'"`
- `git diff --check`
- `node scripts/validate-showcase.mjs`