### PR TITLE
docs: add ArewaOS demo video to showcase

### DIFF
--- a/showcase/arewaos/README.md
+++ b/showcase/arewaos/README.md
@@ -35,6 +35,12 @@ The package isolates the ArewaOS build story, agent manifest, offerings, and mar
 - `examples/market-receipt-colombia-group-k.md` — external prediction-market receipt example.
 - `skills/arewaos-showcase/SKILL.md` — reusable workflow for evaluating or packaging ArewaOS-style agent showcases.
 
+## Demo Video
+
+- YouTube demo video: https://youtube.com/shorts/zkWaoRyqmZc
+
+The demo video shows ArewaOS live on Virtuals with the agent profile, job offerings, Base token context, and the builder story behind a phone-first non-developer launch from Kano, Nigeria.
+
 ## Links
 
 - ACP Agent: https://app.virtuals.io/acp/agents/019e9392-b91c-75fe-bb14-a12e8ffb7561

--- a/showcase/arewaos/showcase.json
+++ b/showcase/arewaos/showcase.json
@@ -2,7 +2,7 @@
   "slug": "arewaos",
   "title": "ArewaOS",
   "tagline": "A seven-layer autonomous Web3 intelligence agent built on Base by a non-developer builder from Kano, Nigeria.",
-  "description": "ArewaOS packages narrative engineering, storytelling, anonymous crypto confessions, on-chain trading analysis, ecosystem scouting, AI-training guidance, and event-probability analysis into one Base-native agent. This showcase includes the public agent manifest, offerings JSON, redacted market-action receipts, and the build story from OpenClaw v1 failure to Hermes v2 rebuild.",
+  "description": "ArewaOS packages narrative engineering, storytelling, anonymous crypto confessions, on-chain trading analysis, ecosystem scouting, AI-training guidance, and event-probability analysis into one Base-native agent. This showcase includes the public agent manifest, offerings JSON, redacted market-action receipts, the public live-agent demo post, and the build story from OpenClaw v1 failure to Hermes v2 rebuild.",
   "status": "active v2 showcase",
   "topic": "agents",
   "topics": [
@@ -19,7 +19,8 @@
   "links": {
     "repo": "https://github.com/Virtual-Protocol/acp-cli-demos/tree/main/showcase/arewaos",
     "demo": "https://github.com/Virtual-Protocol/acp-cli-demos/blob/main/showcase/arewaos/examples/market-receipt-chefuniverse-cfCAVIAR.md",
-    "share": "https://x.com/0xarewah",
+    "video": "https://youtube.com/shorts/zkWaoRyqmZc",
+    "share": "https://youtube.com/shorts/zkWaoRyqmZc",
     "feedback": "https://github.com/Virtual-Protocol/acp-cli-demos/issues/new?title=Feedback%3A%20ArewaOS&body=Which%20feedback%20prompt%20fits%3F%0A%0A-%20The%20agent%20story%20is%20clear%0A-%20The%20offerings%20need%20more%20pricing%20detail%0A-%20The%20proof%20receipts%20need%20stronger%20verification%0A%0ANotes%3A%0A"
   },
   "primitives": [
@@ -28,9 +29,10 @@
     "acp"
   ],
   "visual": {
-    "kind": "agent showcase",
-    "eyebrow": "base + hermes + acp",
-    "title": "seven-layer agent"
+    "kind": "youtube demo video",
+    "eyebrow": "base + virtuals + acp",
+    "title": "live agent from kano",
+    "videoLabel": "Watch the ArewaOS live-agent demo on YouTube"
   },
   "skills": [
     {
@@ -42,6 +44,11 @@
     }
   ],
   "artifacts": [
+    {
+      "label": "ArewaOS live-agent demo video",
+      "href": "https://youtube.com/shorts/zkWaoRyqmZc",
+      "kind": "video"
+    },
     {
       "label": "ArewaOS package README",
       "href": "https://github.com/Virtual-Protocol/acp-cli-demos/blob/main/showcase/arewaos/README.md",
@@ -78,8 +85,8 @@
     "summary": "Public/redacted ArewaOS agent context, seven layers, boundaries, and review preferences."
   },
   "feedbackPrompts": [
+    "Does the live-agent demo make the non-developer builder story clear?",
     "Which ArewaOS layer should become the next standalone ACP offering?",
-    "Are the market-action receipts specific enough for reviewer verification?",
-    "What proof would make the non-developer builder story even stronger?"
+    "What proof would make the agent hiring workflow even stronger?"
   ]
 }


### PR DESCRIPTION
## Summary
- Adds the ArewaOS YouTube demo video to `showcase/arewaos/showcase.json` as `links.video`.
- Updates the showcase hero metadata to point viewers to the YouTube demo.
- Adds the YouTube demo as the first video artifact.
- Documents the demo video link in the ArewaOS package README.

## Why
PR #3 merged the ArewaOS showcase, but the demo video proof was missing from the showcase metadata. This follow-up PR wires the public YouTube demo into the existing accepted package without changing the package structure.

## Demo
https://youtube.com/shorts/zkWaoRyqmZc

## Validation
- [x] `node scripts/validate-showcase.mjs`

Validated 3 showcase project manifest(s).