### PR TITLE
docs(showcase): define video field contract and harden manifest validation

### DIFF
--- a/scripts/validate-showcase.mjs
+++ b/scripts/validate-showcase.mjs
@@ -9,6 +9,35 @@ const showcaseDir = path.join(repoRoot, 'showcase')
 const primitives = new Set(['wallet', 'email', 'card', 'token', 'acp'])
 const slugPattern = /^[a-z0-9]+(?:-[a-z0-9]+)*$/
 const httpPattern = /^https?:\/\//
+const videoPageHostPattern =
+  /(?:^|\.)(?:youtube\.com|youtu\.be|x\.com|twitter\.com|vimeo\.com|tiktok\.com|loom\.com|github\.com)$/i
+const sharePreviewHostPattern =
+  /(?:^|\.)(?:dropbox\.com|drive\.google\.com|docs\.google\.com|1drv\.ms|onedrive\.live\.com|mega\.nz|mediafire\.com|wetransfer\.com)$/i
+const videoFilePattern = /\.(?:mp4|webm|mov|m4v)$/i
+// host pattern -> keyword the videoLabel must contain for that platform
+const platformLabelRules = [
+  [/(?:^|\.)(?:youtube\.com|youtu\.be)$/i, /youtube/i, 'YouTube'],
+  [/(?:^|\.)(?:x\.com|twitter\.com)$/i, /\bX\b|twitter|\u{1D54F}/iu, 'X'],
+  [/(?:^|\.)vimeo\.com$/i, /vimeo/i, 'Vimeo'],
+  [/(?:^|\.)tiktok\.com$/i, /tiktok/i, 'TikTok'],
+  [/(?:^|\.)loom\.com$/i, /loom/i, 'Loom'],
+]
+
+function hostOf(url) {
+  try {
+    return new URL(url).hostname.toLowerCase().replace(/\.$/, '')
+  } catch {
+    return ''
+  }
+}
+
+function pathOf(url) {
+  try {
+    return new URL(url).pathname.toLowerCase()
+  } catch {
+    return ''
+  }
+}
 
 function fail(message) {
   throw new Error(message)
@@ -129,13 +158,59 @@ function validateProject(project, file) {
   for (const key of ['kind', 'eyebrow', 'title']) {
     requireString(project.visual, key, `${file}: visual.${key}`)
   }
-  for (const key of ['posterUrl', 'videoUrl']) {
-    if (project.visual[key] !== undefined && typeof project.visual[key] !== 'string') {
-      fail(`${file}: visual.${key} must be a string`)
+  if (project.visual.videoUrl !== undefined) {
+    requireUrl(project.visual.videoUrl, `${file}: visual.videoUrl`)
+    const videoHost = hostOf(project.visual.videoUrl)
+    if (videoPageHostPattern.test(videoHost)) {
+      fail(
+        `${file}: visual.videoUrl must be a direct video file, not a video or repo page. ` +
+          'Put the page URL in links.video instead, then either omit visual.videoUrl ' +
+          '(YouTube, Vimeo, TikTok, Loom) or use the direct file URL ' +
+          '(X posts: video.twimg.com; GitHub repo files: raw.githubusercontent.com). ' +
+          'See showcase/README.md "Video Fields".',
+      )
+    }
+    if (sharePreviewHostPattern.test(videoHost)) {
+      fail(
+        `${file}: visual.videoUrl is a share/preview page that cannot stream inline. ` +
+          'Use a direct file host instead (for Dropbox: dl.dropboxusercontent.com; ' +
+          'otherwise a CDN, object storage, or raw.githubusercontent.com). ' +
+          'See showcase/README.md "Video Fields".',
+      )
+    }
+    if (!videoFilePattern.test(pathOf(project.visual.videoUrl))) {
+      fail(
+        `${file}: visual.videoUrl must point to a .mp4, .webm, .mov, or .m4v file ` +
+          'so the docs site can play it inline. See showcase/README.md "Video Fields".',
+      )
+    }
+  }
+  if (project.visual.posterUrl !== undefined) {
+    const poster = project.visual.posterUrl
+    const isSiteRelative =
+      typeof poster === 'string' && poster.startsWith('/') && !poster.startsWith('//')
+    if (!isSiteRelative) {
+      requireUrl(poster, `${file}: visual.posterUrl`)
     }
   }
   if (project.visual.videoLabel !== undefined) {
     requireString(project.visual, 'videoLabel', `${file}: visual.videoLabel`)
+  }
+  if (project.links.video !== undefined) {
+    requireString(
+      project.visual,
+      'videoLabel',
+      `${file}: visual.videoLabel (required when links.video is set; it becomes the watch button text)`,
+    )
+    const videoHost = hostOf(project.links.video)
+    for (const [hostPattern, labelPattern, platformName] of platformLabelRules) {
+      if (hostPattern.test(videoHost) && !labelPattern.test(project.visual.videoLabel)) {
+        fail(
+          `${file}: visual.videoLabel must mention ${platformName} when links.video points there, ` +
+            `for example "Watch the 1:50 demo on ${platformName}"`,
+        )
+      }
+    }
   }
 
   if (!Array.isArray(project.skills)) fail(`${file}: skills must be an array`)

--- a/showcase/README.md
+++ b/showcase/README.md
@@ -34,6 +34,10 @@ Use the Paid Substack example as the reference:
   example
 - `skills/acp-paid-subscription-checkout/examples/substack/`
 
+Note: that reference manifest uses a site-relative `visual.posterUrl`, which is
+a maintainer-managed asset in the docs repo. Contributor PRs must use an
+`https://` poster URL instead — see [Video Fields](#video-fields).
+
 Every manifest needs:
 
 - `slug`, `title`, `tagline`, `description`, `status`, `topic`, and `topics`
@@ -41,7 +45,8 @@ Every manifest needs:
 - `links.repo`, `links.share`, and `links.feedback`
 - `primitives`, using `wallet`, `email`, `card`, `token`, or `acp`
 - `visual.kind`, `visual.eyebrow`, and `visual.title`
-- `skills`, when the workflow is reusable
+- `skills`, when the workflow is reusable; each entry needs `name`, `href`,
+  `summary`, and `install`
 - `skills[].sourcePath`, when the skill is committed in this repo and should be
   validated against a local `SKILL.md`
 - `artifacts`, including proof and redacted reports for live workflows
@@ -51,6 +56,80 @@ An X video is highly recommended when possible because it is visual and easy to
 share, but it is not required. Use any inspectable artifact that shows the
 project or workflow ran: screenshot, hosted video, animated demo, live page,
 interactive demo, public PR, demo repo, or redacted result report.
+
+## Video Fields
+
+Use these rules whenever the submission includes a video. The docs site plays
+a video inline when `visual.videoUrl` is a direct video file, embeds a
+click-to-play YouTube player when `links.video` is a YouTube URL, and links
+every other video page out to its own platform.
+
+| Where the video lives | `links.video` | `visual.videoUrl` | `visual.posterUrl` (recommended, not required) | `visual.videoLabel` |
+| --- | --- | --- | --- | --- |
+| X post | the `x.com/<user>/status/<id>` post URL | the direct `https://video.twimg.com/....mp4` file URL | the `https://pbs.twimg.com/amplify_video_thumb/...` image from the same capture | `Watch the 1:50 demo on X` |
+| YouTube | the watch or Shorts URL | omit — the docs site embeds the YouTube player from `links.video` | `https://img.youtube.com/vi/<video-id>/maxresdefault.jpg` | `Watch the 1:50 demo on YouTube` |
+| Vimeo, TikTok, Loom, or another video page | the page URL | omit — page URLs cannot play inline, and tokenized CDN file URLs extracted from players expire | commit a captured frame under `showcase/<slug>/assets/` | `Watch the 1:50 demo on Vimeo` |
+| Self-hosted file | a public page when one exists, otherwise the file URL | the direct `.mp4` file URL (see hosting notes below) | recommended | `Watch the 1:50 demo` |
+| No video | omit | omit | optional — prefer adding screenshots under `artifacts`; a poster without a video renders as a static image | omit |
+
+Replace `1:50` with the real video duration.
+
+Field meanings and what the validator enforces:
+
+- `links.video` is the public watch page. Point `links.share` at the same post
+  or page unless a separate announcement post should be shared. Also list the
+  video under `artifacts` with kind `video` so it is reachable from the
+  project detail view.
+- `visual.videoUrl` must be a direct video file that a browser video tag can
+  stream. `.mp4` (H.264) is strongly preferred because it plays everywhere;
+  `.webm` does not play in older Safari, and `.mov`/`.m4v` are accepted but
+  discouraged. The validator rejects video page URLs (YouTube, X, Vimeo,
+  TikTok, Loom), repo pages (`github.com/.../blob/...`), and share or preview
+  links (Dropbox, Google Drive, OneDrive, and similar) because they serve an
+  HTML page instead of the file. For a file committed in a GitHub repo, use
+  its `raw.githubusercontent.com` URL. For Dropbox, use a
+  `dl.dropboxusercontent.com` URL. Do not use tokenized CDN URLs pulled out
+  of Vimeo or similar players; they expire and silently break the card.
+- `visual.posterUrl` must be an `https://` image URL. It is recommended for
+  every video and required for none. For YouTube, use the thumbnail
+  `https://img.youtube.com/vi/<video-id>/maxresdefault.jpg`; the `<video-id>`
+  is the `v=` query parameter on watch URLs or the last path segment of
+  `youtube.com/shorts/<id>` and `youtu.be/<id>` links. If `maxresdefault.jpg`
+  returns 404, use `sddefault.jpg`; `hqdefault.jpg` is 4:3 and gets visibly
+  cropped on the 16:9 card. For X videos, copy the
+  `https://pbs.twimg.com/amplify_video_thumb/...` image URL from the same
+  devtools capture as the video file. To ship a poster inside this repo,
+  commit it as `showcase/<slug>/assets/poster.jpg` and reference
+  `https://raw.githubusercontent.com/Virtual-Protocol/acp-cli-demos/main/showcase/<slug>/assets/poster.jpg`;
+  the `main` URL resolves only after the PR merges, so verify the same path
+  on your fork or branch instead. Site-relative paths such as
+  `/showcase/<slug>-poster.jpg` are maintainer-managed assets in the docs
+  repo; do not use them in contributor PRs.
+- `visual.videoLabel` is required whenever `links.video` is set. It is the
+  watch-button text for featured builds and the accessible label on the
+  card's play link, so it must name the platform the viewer lands on. The
+  validator enforces the platform mention for YouTube, X, Vimeo, TikTok, and
+  Loom links. For self-hosted files a plain `Watch the 1:50 demo` is correct.
+
+To get the direct file URL from an X post: open the post in a browser, open
+developer tools, filter network requests by `video.twimg.com`, play the video,
+and copy the highest-resolution `.mp4` request URL.
+
+Verify before requesting review (humans and AI agents):
+
+```bash
+# Expect HTTP 200 and content-type: video/...
+# GitHub raw serves video files as application/octet-stream; in that case
+# confirm playback by opening the URL in a browser instead.
+curl -sI "<visual.videoUrl>"
+
+# Expect HTTP 200 and content-type: image/...
+# For a repo-committed poster, check the raw URL on your fork or branch;
+# the main URL only resolves after merge.
+curl -sI "<visual.posterUrl>"
+
+node scripts/validate-showcase.mjs
+```
 
 Optional visibility control:
 

--- a/showcase/arewaos/showcase.json
+++ b/showcase/arewaos/showcase.json
@@ -32,6 +32,7 @@
     "kind": "youtube demo video",
     "eyebrow": "base + virtuals + acp",
     "title": "live agent from kano",
+    "posterUrl": "https://img.youtube.com/vi/zkWaoRyqmZc/maxresdefault.jpg",
     "videoLabel": "Watch the ArewaOS live-agent demo on YouTube"
   },
   "skills": [


### PR DESCRIPTION
## Summary
- Add a "Video Fields" section to `showcase/README.md` so contributors (humans and AI agents) know exactly which manifest fields to set per video source: X post, YouTube, Vimeo/TikTok/Loom, self-hosted file, or no video — including hosting rules, poster recipes, and pre-review `curl` verification steps.
- Harden `scripts/validate-showcase.mjs` against values that pass validation but render broken on the docs site:
  - reject video page URLs (YouTube, X, Vimeo, TikTok, Loom), `github.com/.../blob/...` repo pages, and Dropbox/Drive/OneDrive share links in `visual.videoUrl`
  - require a direct video file extension on the URL pathname (so `watch?v=clip.mp4` fails but `demo.mp4#t=0,30` passes)
  - require `visual.videoLabel` whenever `links.video` is set, and check it names the linked platform
  - block protocol-relative `//host` poster URLs and normalize trailing-dot hostnames
- Add the missing ArewaOS poster via its YouTube thumbnail so the featured card is not text-only.

## Context
The featured Showcase build (ArewaOS) shipped a YouTube-only video with no poster, which surfaced that the manifest format had no documented video contract: the docs site can only play direct video files inline, but nothing told contributors that or validated it.

## Tests
- `node scripts/validate-showcase.mjs` passes all 3 existing manifests.
- 13 negative fixtures (page URLs, share links, query-tail extensions, protocol-relative posters, wrong platform labels, trailing-dot hosts) all rejected with actionable messages; legitimate edge cases (`.mp4#t=0,30` fragments, `raw.githubusercontent.com` files) pass.
- Live URL checks: the ArewaOS YouTube thumbnail returns `200 image/jpeg`; the existing twimg `.mp4` returns `200 video/mp4`.

Companion renderer changes (label/destination fixes + click-to-load YouTube embed) land in `whitepaper-economyOS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)