### PR TITLE
feat(showcase): add acp-sec — security scanning & Trust Score for ACP agents

### DIFF
--- a/showcase/acp-sec/README.md
+++ b/showcase/acp-sec/README.md
@@ -1,0 +1,89 @@
+# ACP-SEC
+
+Security scanning & Trust Score for ACP agents.
+
+ACP-SEC computes a **Trust Score** (0-100, graded A to F) for an on-chain agent
+contract so that other agents and humans can decide whether to transact with it.
+It is read-only: it inspects public on-chain data and verified source, and never
+signs, transfers, or mutates the contract it assesses.
+
+## What It Does
+
+Given a contract address on Base, ACP-SEC runs a read-only assessment across six
+security dimensions and returns a single composite Trust Score plus the
+underlying findings. Scoring is conservative — a CRITICAL finding caps the
+score, and any dimension whose data cannot be verified from public sources is
+marked **Unrated** (which lowers the confidence multiplier) rather than assumed
+safe. Every score ships with its subscores, top findings, the list of Unrated
+checks, the scanner version, and a UTC timestamp, so a reviewer can reproduce
+and audit it.
+
+## How Builders Use It
+
+Run a scan **before** you delegate authority or commit to a job:
+
+- **Counterparty check** — scan another agent's contract in `external` mode
+  (public/on-chain data only) before hiring it or accepting a job from it.
+- **Self-audit** — scan your own agent in `self_audit` mode, supplying private
+  data such as Agent Card spend limits, to see the score a counterparty would
+  compute and to find gaps before you ship.
+
+```bash
+# External scan of any ACP agent contract
+acpsec trust-score --agent 0x... --chain base-sepolia --scan-mode external --output scan.json
+
+# Or as the executor behind the acp-sec ACP Provider
+python -m acpsec.acp_provider "scan 0x..." --chain base-sepolia
+```
+
+Read the result as the numeric **Trust Score (0-100)** and its **letter grade
+(A ≥ 90, B ≥ 75, C ≥ 60, D ≥ 40, F below 40)**, together with the per-dimension
+subscores and findings. Treat a `critical: true` result as a hard stop
+regardless of the numeric score.
+
+## Trust Score Dimensions
+
+1. **Contract Security** — source verification and Slither static analysis
+   (reentrancy, delegatecall, selfdestruct, access control, floating pragma).
+2. **Authority Scope** — owner/admin powers, spend limits, pause/emergency-stop,
+   key-rotation posture.
+3. **Identity** — ERC-8004 registration and sybil/handle verification.
+4. **Hook Security** — settlement-hook ownership and static-analysis findings.
+5. **ERC-8183 / ACP Compliance** — ACP lifecycle phases, fee-split conformance,
+   and atomic settlement.
+6. **Behavioral** — on-chain transfer-event history.
+
+## Proof of Work
+
+We scanned our own reference contract, **SentryAgent**, deployed and verified on
+Base Sepolia, in `external` scan mode — the exact output a builder sees when
+scanning a counterparty:
+
+- **Score: 80 — Grade B, `critical: false`**
+- Contract Security 100, Hook Security 100, Behavioral 100
+- Authority Scope 60, ACP Compliance 70, Identity 50
+- Top findings: no on-chain spending cap (High), no ERC-8004 identity (High),
+  unverified handle (High), missing ACP v3 lifecycle phase (High).
+
+Full per-dimension breakdown, the Unrated checks, and every finding:
+[`examples/sentryagent-baseline-proof.md`](examples/sentryagent-baseline-proof.md).
+
+## Roadmap
+
+Honest status:
+
+- **Now (live):** the `acp-sec-scan` skill and CLI Trust Score across all six
+  dimensions, with reproducible scan JSON. This is what ships in this showcase.
+- **Phase 2 (WIP):** ACP Provider integration — running ACP-SEC as a seller-side
+  ACP Provider so other agents can purchase scans over the protocol. The
+  provider skeleton and scan bridge exist; the full ACP lifecycle round-trip is
+  still in progress.
+- **Phase 3+ (planned):** a multi-agent reasoning layer that combines scans,
+  cross-references identity/behavior over time, and explains score deltas
+  between assessments.
+
+## Links
+
+- Repo: https://github.com/acpsec/acp-sec
+- Feedback / issues: https://github.com/acpsec/acp-sec/issues
+- Builder: https://x.com/acpsecagent

--- a/showcase/acp-sec/examples/sentryagent-baseline-proof.md
+++ b/showcase/acp-sec/examples/sentryagent-baseline-proof.md
@@ -1,0 +1,62 @@
+# Proof of Work — SentryAgent Baseline Scan
+
+This is a **real** ACP-SEC scan, not a mock. We scanned our own reference
+contract, **SentryAgent**, deployed and verified on **Base Sepolia**, in
+`external` scan mode. External mode uses only public/on-chain data and verified
+source — exactly what a counterparty agent would have when it scans you. The
+JSON below is the unmodified scanner output a builder sees.
+
+- **Target:** `0x7770ED57E3993d4555951a557cd158a6Fb87A470` (Base Sepolia)
+- **Scan mode:** `external` (public data only)
+- **Scanner:** `acpsec-v0.5.0`
+- **Scanned at:** `2026-06-09T08:28:23Z`
+- **Source:** [`scans/baseline-sentryagent-sepolia-2026-06-09.json`](https://github.com/acpsec/acp-sec/blob/main/scans/baseline-sentryagent-sepolia-2026-06-09.json)
+
+## Result
+
+| | |
+| --- | --- |
+| **Trust Score** | **80 / 100** |
+| **Grade** | **B** |
+| **Critical** | `false` |
+| **Confidence multiplier** | `0.85` |
+| **ERC-8004 ID** | none registered |
+
+## Per-dimension subscores
+
+| Dimension | Score | Unrated checks |
+| --- | --- | --- |
+| Contract Security | 100 | — |
+| Authority Scope | 60 | `signer_unrestricted`, `agent_card_no_spend_limit` |
+| Identity | 50 | — |
+| Hook Security | 100 | — |
+| ERC-8183 / ACP Compliance | 70 | `fee_split_nonconformant` |
+| Behavioral | 100 | — |
+
+The two Unrated authority-scope checks are *not* passes — they are checks whose
+data is not provable from public state in `external` mode (an operator could
+resolve them with a `self_audit`). Unrated data lowers the confidence
+multiplier rather than scoring as safe.
+
+## Top findings (by severity)
+
+| Severity | Dimension | Detail |
+| --- | --- | --- |
+| High | Authority Scope | no on-chain spending budget or per-period cap |
+| High | Identity | no ERC-8004 identity registered |
+| High | Identity | claimed handle unverified |
+| High | ACP Compliance | missing ACP v3 lifecycle phase (1 of 1) |
+| Medium | Authority Scope | no pause / emergency-stop mechanism |
+| Medium | ACP Compliance | settlement not atomic |
+| Low | Authority Scope | no key rotation path documented |
+
+## How to read this
+
+Contract Security, Hook Security, and Behavioral all scored 100 — the source is
+verified, Slither found nothing material, the hooks are owned correctly, and the
+on-chain transfer history is clean. The score is pulled down to 80 by Authority
+Scope (no spend caps, no pause), Identity (no ERC-8004 registration, unverified
+handle), and an ACP-compliance gap (a missing lifecycle phase, non-atomic
+settlement). None of the findings are CRITICAL, so `critical` is `false` and the
+contract grades **B** — usable, but a counterparty should note the unbounded
+authority and missing identity before delegating real value.

--- a/showcase/acp-sec/showcase.json
+++ b/showcase/acp-sec/showcase.json
@@ -1,0 +1,67 @@
+{
+  "slug": "acp-sec",
+  "title": "ACP-SEC",
+  "tagline": "Security scanning & Trust Score for ACP agents",
+  "description": "ACP-SEC scans an agent contract — your own or a counterparty's — before you delegate authority or commit to a job. It produces a Trust Score (0-100, graded A to F) across six dimensions: contract security, authority scope, identity, hooks, ERC-8183/ACP compliance, and on-chain behavior. The identity and compliance dimensions include ERC-8004 and ERC-8183 conformance checks.",
+  "status": "live",
+  "topic": "skills",
+  "topics": [
+    "security",
+    "audit",
+    "trust-score",
+    "erc-8183",
+    "erc-8004"
+  ],
+  "builder": {
+    "name": "acpsec",
+    "url": "https://x.com/acpsecagent"
+  },
+  "links": {
+    "repo": "https://github.com/acpsec/acp-sec",
+    "feedback": "https://github.com/acpsec/acp-sec/issues",
+    "share": "https://x.com/acpsecagent"
+  },
+  "primitives": [
+    "acp"
+  ],
+  "visual": {
+    "kind": "security scan report",
+    "eyebrow": "base + acp + erc-8004/8183",
+    "title": "trust score for acp agents"
+  },
+  "skills": [
+    {
+      "name": "acp-sec-scan",
+      "href": "https://github.com/Virtual-Protocol/acp-cli-demos/tree/main/showcase/acp-sec/skills/acp-sec-scan",
+      "sourcePath": "showcase/acp-sec/skills/acp-sec-scan",
+      "summary": "Run an acp-sec Trust Score scan on an on-chain ACP agent contract and interpret the score, subscores, top findings, and Unrated dimensions — standalone via CLI or as the executor behind the acp-sec ACP Provider.",
+      "install": "cp -R showcase/acp-sec/skills/acp-sec-scan ~/.agents/skills/\ncp -R showcase/acp-sec/skills/acp-sec-scan ~/.claude/skills/"
+    }
+  ],
+  "artifacts": [
+    {
+      "label": "SentryAgent baseline Trust Score (80 / B, Base Sepolia)",
+      "href": "https://github.com/Virtual-Protocol/acp-cli-demos/blob/main/showcase/acp-sec/examples/sentryagent-baseline-proof.md",
+      "kind": "proof"
+    },
+    {
+      "label": "ACP-SEC package README",
+      "href": "https://github.com/Virtual-Protocol/acp-cli-demos/blob/main/showcase/acp-sec/README.md",
+      "kind": "docs"
+    },
+    {
+      "label": "acp-sec-scan skill source",
+      "href": "https://github.com/Virtual-Protocol/acp-cli-demos/tree/main/showcase/acp-sec/skills/acp-sec-scan",
+      "kind": "skill"
+    }
+  ],
+  "soul": {
+    "href": "https://github.com/Virtual-Protocol/acp-cli-demos/blob/main/showcase/acp-sec/soul.md",
+    "summary": "Public acp-sec agent context: what it scans, its A-F grade scale, its read-only and secret-handling boundaries, and its proof-over-claims review preference."
+  },
+  "feedbackPrompts": [
+    "Are the six Trust Score dimensions the right ones for deciding whether to transact with an ACP agent?",
+    "Is conservative Unrated-by-default scoring (missing data lowers confidence rather than passing) the right call?",
+    "What additional proof would make a Trust Score trustworthy enough to gate real authority delegation?"
+  ]
+}

--- a/showcase/acp-sec/skills/acp-sec-scan/SKILL.md
+++ b/showcase/acp-sec/skills/acp-sec-scan/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: acp-sec-scan
+description: Run an acp-sec Trust Score scan on an on-chain ACP agent contract and interpret the result.
+version: 0.5.0
+---
+
+# acp-sec Trust Score Scan
+
+Use this skill to assess whether an on-chain agent contract is safe to transact
+with, by computing an acp-sec **Trust Score** (0-100, graded A to F) across six
+security dimensions. Works standalone (CLI) or as the executor behind the
+acp-sec ACP Provider.
+
+## Prerequisites
+
+Complete these before invoking the skill — copying the skill folder does **not**
+install the `acpsec` CLI it calls.
+
+1. Install `acpsec` from source:
+   ```bash
+   git clone https://github.com/acpsec/acp-sec.git
+   cd acp-sec
+   python3 -m venv .venv && source .venv/bin/activate
+   pip install -e .
+   ```
+2. Optional but recommended — enable Dimension 1 (Contract Security) deep checks:
+   ```bash
+   pip install slither-analyzer
+   ```
+3. Export a `BASESCAN_API_KEY` (Etherscan V2 unified key — one key works for Base
+   mainnet and Base Sepolia via the `chainid` param):
+   ```bash
+   export BASESCAN_API_KEY=your_key_here   # get one at https://etherscan.io/apis
+   ```
+4. Verify the install:
+   ```bash
+   acpsec trust-score --help
+   ```
+
+## Inputs
+
+- A target contract address (`0x...`) on Base.
+- Chain: `base-sepolia` (default) or `base-mainnet`.
+- Scan mode: `external` (public/on-chain data only) or `self_audit` (operator
+  may supply private data such as Agent Card spend limits).
+- A `BASESCAN_API_KEY` (Etherscan V2 unified key) for contract source/ABI.
+
+## Workflow
+
+1. Confirm the input is a public contract address, never a private key.
+2. Run the scan:
+   ```bash
+   acpsec trust-score --agent 0x... --chain base-sepolia --scan-mode external --output scan.json
+   ```
+   Or, as the ACP Provider bridge:
+   ```bash
+   python -m acpsec.acp_provider "scan 0x..." --chain base-sepolia
+   ```
+3. Read the result: `score`, `grade`, `critical`, the six `subscores`,
+   `top_findings` (sorted by severity), and any `unrated_checks`.
+4. Interpret the numeric score (0-100) and letter grade (A ≥ 90, B ≥ 75, C ≥ 60,
+   D ≥ 40, F below 40) together with the subscores and findings. Treat a
+   `critical: true` result as a hard stop regardless of the numeric score.
+5. Note Unrated dimensions: missing data is reported as Unrated and lowers the
+   confidence multiplier; do not read it as "safe".
+
+## Output
+
+Return the Trust Score JSON (or the ACP deliverable wrapping it), including the
+score, grade, subscores, top findings, the list of Unrated checks, the scanner
+version, and the UTC scan timestamp so a reviewer can reproduce and audit it.
+
+## Boundaries / stop conditions
+
+- Read-only: never sign, transfer, or mutate the assessed contract.
+- Never log, print, or include private keys, session keys, wallet material, or
+  API keys in any output or proof artifact.
+- If contract source is unverified or data is unavailable, report it (Unrated)
+  rather than guessing.
+- A Trust Score is a point-in-time assessment, not a guarantee or financial
+  advice.

--- a/showcase/acp-sec/soul.md
+++ b/showcase/acp-sec/soul.md
@@ -1,0 +1,52 @@
+# acp-sec Agent Soul
+
+acp-sec is a security-assessment agent for the Agent Commerce Protocol (ACP). It
+computes a **Trust Score** (0-100, graded A to F) for an on-chain agent contract so
+that other agents and humans can decide whether to transact with it.
+
+## What it does
+
+Given a contract address on Base, acp-sec runs a read-only assessment across six
+dimensions and returns a single composite Trust Score plus the underlying
+findings:
+
+1. **Contract Security** — source verification and Slither static analysis
+   (reentrancy, delegatecall, selfdestruct, access control, floating pragma).
+2. **Authority Scope** — owner/admin powers, spend limits, pause/emergency-stop,
+   key-rotation posture.
+3. **Identity** — ERC-8004 registration and sybil/handle verification.
+4. **Hook Security** — settlement-hook ownership and static-analysis findings.
+5. **ERC-8183 / ACP Compliance** — ACP lifecycle phases, fee-split conformance,
+   atomic settlement, and ERC-8183 conformance.
+6. **Behavioral** — on-chain transfer-event history.
+
+Scoring is conservative: a CRITICAL finding caps the score, and any dimension
+whose data cannot be verified from public sources is marked **Unrated** rather
+than assumed safe (which also lowers the confidence multiplier).
+
+## Grade
+
+The Trust Score is a 0-100 number with a letter grade: A ≥ 90, B ≥ 75, C ≥ 60,
+D ≥ 40, F below 40. A CRITICAL finding caps the score regardless of the
+subscores. The score and grade are the trust signal; there are no separate band
+labels.
+
+## Boundaries
+
+- Read-only. acp-sec inspects public on-chain data and verified source; it never
+  signs transactions on the target, moves funds, or mutates the assessed agent.
+- It never publishes or logs private keys, session keys, wallet material, API
+  keys, or other secrets. A scan target is a public address, never a key.
+- An "external" scan uses only public/on-chain data; private inputs (e.g. Agent
+  Card spend limits) are left Unrated unless an operator runs a "self_audit".
+- Trust Scores are point-in-time assessments, not guarantees. A high score is
+  not investment, custody, or safety advice.
+- Live spending, public posting, account creation, deployment, and production
+  mutations require explicit human approval.
+
+## Review preference
+
+acp-sec favors inspectable proof over claims: verified contract source, on-chain
+reads with block references, Slither output, and reproducible scan JSON. Every
+Trust Score carries its subscores, top findings, the list of Unrated checks, the
+scanner version, and a UTC timestamp so a reviewer can reproduce and audit it.


### PR DESCRIPTION
# Showcase Project

## What shipped

- Project slug: `acp-sec`
- Project title: ACP-SEC
- Builder name and URL: acpsec — https://x.com/acpsecagent
- EconomyOS primitives used: `acp`
- Public proof: real (redacted) baseline scan report — `showcase/acp-sec/examples/sentryagent-baseline-proof.md` — SentryAgent scored **80 / Grade B** in `external` mode on Base Sepolia, reproducible from `acpsec-v0.5.0`. No video.
- Optional soul.md: `showcase/acp-sec/soul.md` (public, redacted; linked from the manifest with a summary)

## Project package

- [x] Added or updated `showcase/<project-slug>/showcase.json`
- [x] Added demo artifacts, prompt, proof, or redacted report
- [x] Added reusable skill under `showcase/<project-slug>/skills/<skill-name>/` when it belongs to this project package
- [ ] Used top-level `skills/<skill-name>/` only when the skill is shared across projects
- [x] Set `skills[].sourcePath` in `showcase.json` for any skill committed in this repo
- [x] Linked all public artifacts from the manifest
- [x] Included exactly three feedback prompts
- [ ] Set `hidden: true` only if this package should merge without publishing its public Showcase card yet
- [x] Linked `soul.md` only if the builder intentionally wants to publish public, redacted agent context

## Skill standard

- Skill path: `showcase/acp-sec/skills/acp-sec-scan/`
- [x] `SKILL.md` includes when to use it and when not to use it
- [x] Inputs, tools, credentials, and preconditions are explicit
- [x] Approval gates are listed for spending, posting, account creation, deployment, or production mutations
- [x] Stop conditions and handoff rules are listed
- [x] Validation checks and output contract are included

## Safety and redaction

- [x] No card numbers, CVVs, OTPs, magic links, API keys, access tokens, private prompts, wallet material, or private account records are published
- [x] Live workflow evidence is redacted
- [x] Public/private boundaries are explained
- [x] Optional `soul.md` does not include private instructions, credentials, account data, wallet material, or operational secrets

## Publish path

After this PR is approved and merged to `main`, changes under
`showcase/**` trigger the EconomyOS docs sync. The accepted manifest is
published into `/community#showcase` by the docs workflow.
