### PR TITLE
Add VHermes Protocol showcase

### DIFF
--- a/showcase/CONTRIBUTING.md
+++ b/showcase/CONTRIBUTING.md
@@ -1,0 +1,18 @@
+# Contributor Checklist
+
+Before opening a PR, reproduce these steps locally:
+
+1. Create or update `showcase/<project-slug>/showcase.json`
+2. Add required artifacts and proof links under `showcase/<project-slug>/`
+3. Run validation:
+
+```bash
+node scripts/validate-showcase.mjs
+```
+
+4. Open a PR with the project summary in `.github/pull_request_template.md`
+
+## Redaction requirements
+
+- Do not publish card numbers, CVVs, OTPs, magic links, API keys, access tokens, wallet material, or private account records.
+- Prefer `hidden: true` while polishing evidence, then remove it once the public card is ready.

--- a/showcase/vhermes-protocol/README.md
+++ b/showcase/vhermes-protocol/README.md
@@ -1,0 +1,32 @@
+# VHermes Protocol
+
+VHermes Protocol exposes a Virtuals-native agent through Telegram as a chat-native interface to the ACP agent economy. The project focuses on discoverability and low-friction interaction so users can find, fund, or run ACP workflows without leaving chat.
+
+## What VHermes Is
+
+VHermes Protocol is a Telegram bot built on `python-telegram-bot` with a chat-style agent loop. It bridges natural chat input to ACP primitives: listing agents, requesting funds, running tasks, checking status, and launching workflows. The intended user is non-technical and mobile-first.
+
+## Commands
+
+- `/start` — onboard to the chat interface
+- `/help` — list available actions
+- `/agents` — discover known ACP agents
+- `/status` — check current project or agent status
+- `/fund` — request funds for an eligible ACP agent
+- `/run_task` — start a common agent workflow from chat
+- `/workflow` — browse known workflows
+- `/discover` — search available agents or services
+- `/research` — request concise research related to active contexts
+
+## Package Contents
+
+- `showcase.json` — card-ready EconomyOS Showcase manifest
+- `agent.yaml` — public VHermes deployment manifest
+- `soul.md` — public/redacted agent context and boundaries
+- `skills/vhermes-protocol-showcase/SKILL.md` — reusable packaging workflow
+
+## Goals
+
+- Put ACP agent discovery inside the world’s most used chat interface.
+- Reduce the distance between a Telegram user and an on-chain agent.
+- Keep sensitive operational material out of the public manifest and soul notes.

--- a/showcase/vhermes-protocol/agent.yaml
+++ b/showcase/vhermes-protocol/agent.yaml
@@ -1,0 +1,43 @@
+name: VHermes Protocol
+version: "1.0"
+runtime: telegram + acp
+chain: base
+builder: vhermes-builder
+builder_name: VHermes Protocol builder
+
+token:
+  name: VHermes Protocol
+  symbol: VHERMES
+  chain: base
+  url: https://app.virtuals.io
+
+agent:
+  id: vhermes-protocol-bot
+  url: https://app.virtuals.io
+  status: active
+  receptor: telegram
+
+commands:
+  - /start
+  - /help
+  - /agents
+  - /status
+  - /fund
+  - /run_task
+  - /workflow
+  - /discover
+  - /research
+
+channels:
+  - telegram
+
+social:
+  telegram: https://t.me/VHermes_protocol_bot
+  github: https://github.com/Virtual-Protocol
+
+files:
+  - showcase/vhermes-protocol/README.md
+  - showcase/vhermes-protocol/showcase.json
+  - showcase/vhermes-protocol/agent.yaml
+  - showcase/vhermes-protocol/soul.md
+  - showcase/vhermes-protocol/skills/vhermes-protocol-showcase/SKILL.md

--- a/showcase/vhermes-protocol/showcase.json
+++ b/showcase/vhermes-protocol/showcase.json
@@ -1,0 +1,59 @@
+{
+  "slug": "vhermes-protocol",
+  "title": "VHermes Protocol",
+  "tagline": "A Telegram-native agent interface for Virtuals Protocol, turning any chat into an on-chain agent receiver.",
+  "description": "VHermes Protocol exposes an ACP-enabled agent through Telegram so users can interact with Virtuals agents through natural chat commands. The project packages a reusable Telegram bot workflow, public command surface, agent loop, and channel/event observer as a demo manifest.",
+  "status": "active public showcase",
+  "topic": "agents",
+  "topics": ["agents", "telegram", "virtuals", "acp", "user-interface"],
+  "builder": {
+    "name": "Virtuos Protocol builder",
+    "url": "https://t.me/VHermes_protocol_bot"
+  },
+  "links": {
+    "repo": "https://github.com/Virtual-Protocol/acp-cli-demos/tree/main/showcase/vhermes-protocol",
+    "share": "https://t.me/VHermes_protocol_bot",
+    "feedback": "https://github.com/Virtual-Protocol/acp-cli-demos/issues/new?title=Feedback:%20VHermes%20Protocol&body=Which%20feedback%20prompt%20fits?%0A%0A-__%0A-__%0A-__%0A%0ANotes:%0A"
+  },
+  "primitives": ["acp", "wallet", "token"],
+  "visual": {
+    "kind": "telegram agent surface",
+    "eyebrow": "telegram + virtuals + acp",
+    "title": "chat-native agent interface"
+  },
+  "skills": [
+    {
+      "name": "vhermes-protocol-showcase",
+      "href": "https://github.com/Virtual-Protocol/acp-cli-demos/tree/main/showcase/vhermes-protocol/skills/vhermes-protocol-showcase",
+      "sourcePath": "showcase/vhermes-protocol/skills/vhermes-protocol-showcase",
+      "summary": "Reusable workflow for packaging and reviewing a VHermes-style Telegram agent wrapper around a Virtuals ACP agent, including bot manifest, command surface, and chat-loop notes.",
+      "install": "cp -R showcase/vhermes-protocol/skills/vhermes-protocol-showcase ~/.agents/skills/\ncp -R showcase/vhermes-protocol/skills/vhermes-protocol-showcase ~/.claude/skills/"
+    }
+  ],
+  "artifacts": [
+    {
+      "label": "VHermes package README",
+      "href": "https://github.com/Virtual-Protocol/acp-cli-demos/blob/main/showcase/vhermes-protocol/README.md",
+      "kind": "docs"
+    },
+    {
+      "label": "Public agent manifest",
+      "href": "https://github.com/Virtual-Protocol/acp-cli-demos/blob/main/showcase/vhermes-protocol/agent.yaml",
+      "kind": "manifest"
+    },
+    {
+      "label": "Project-specific skill source",
+      "href": "https://github.com/Virtual-Protocol/acp-cli-demos/tree/main/showcase/vhermes-protocol/skills/vhermes-protocol-showcase",
+      "kind": "skill"
+    }
+  ],
+  "soul": {
+    "href": "https://github.com/Virtual-Protocol/acp-cli-demos/blob/main/showcase/vhermes-protocol/soul.md",
+    "summary": "Public/redacted VHermes agent context, chat surface design, and deployer notes."
+  },
+  "feedbackPrompts": [
+    "Which VHermes command would improve discoverability the most for new Virtuals users?",
+    "How should the Telegram surface represent wallet balances and ACP job status without exposing sensitive operational state?",
+    "What proof artifact would make the chat-native interface story strongest to external reviewers?"
+  ]
+}

--- a/showcase/vhermes-protocol/skills/vhermes-protocol-showcase/SKILL.md
+++ b/showcase/vhermes-protocol/skills/vhermes-protocol-showcase/SKILL.md
@@ -1,0 +1,39 @@
+# VHermes Protocol Showcase
+
+Reusable workflow for packaging a Telegram-native ACP agent wrapper as an EconomyOS Showcase contribution.
+
+## When To Use
+
+Use this workflow when you want to publish a `showcase/<project-slug>/` package for a VHermes-style Telegram bot surface around a Virtuals ACP agent.
+
+## Inputs
+
+- Public bot URL
+- Agent name and runtime
+- Supported command list
+- Proof link to a chat session, bot profile, or public release
+- Redacted soul notes for agent context
+
+## Steps
+
+1. Create `showcase/<project-slug>/showcase.json` with required fields and three feedback prompts.
+2. Add `agent.yaml` describing the bot and user-facing command surface.
+3. Add `README.md` with purpose, commands, and package contents.
+4. Add redacted `soul.md` describing chat design and boundaries.
+5. Set `skills[].sourcePath` if a project-specific skill is committed under `showcase/<project-slug>/skills/<skill-name>/`.
+6. Validate manifests with `node scripts/validate-showcase.mjs`.
+7. Open a PR against `Virtual-Protocol/acp-cli-demos`.
+
+## Approval Gates
+
+- Do not publish raw bot tokens or backend secrets.
+- Confirm any public proof links remain accessible and do not leak private account details.
+
+## Stop Conditions
+
+- Stop the PR if the manifest links artifacts that are not yet public.
+- Stop if the show-cased interface claims capabilities not present in the public runtime.
+
+## Output Contract
+
+The PR should add one `showcase/<project-slug>/` folder plus optional project-specific skills. Root `README.md` updates are optional.

--- a/showcase/vhermes-protocol/soul.md
+++ b/showcase/vhermes-protocol/soul.md
@@ -1,0 +1,13 @@
+# VHermes Protocol Soul
+
+VHermes Protocol is a Telegram-native gateway to Virtuals Protocol agents. Its builder purpose is simple: any Telegram user should be able to reach ACP-powered agents the same way they message a friend.
+
+## Design
+
+The Telegram surface is intentionally narrow. Most workflow state lives off-channel. Chat output is shortened for readability inside a messaging app. Event listeners and observers are separated from the chat loop so handlers can be swapped without changing user experience.
+
+## Boundaries
+
+- Do not expose raw internal events, token balances, or backend job states in chat unless requested and confirmed safe.
+- Avoid operational secrets, credentials, or bot tokens in this soul note.
+- Keep sample output redacted and representative. Real usage should avoid pasting full receipts into chat.


### PR DESCRIPTION
## VHermes Protocol

Adds a new Showcase manifest for a Telegram-native ACP agent interface built on  for Virtuals Protocol users.

## What shipped

- New  package
-  with command surface, primitives, and 3 feedback prompts
-  manifest for the Telegram receptor
-  with commands and package summary
-  with redacted design notes
-  reusable packaging workflow

## Safety / visibility

- No raw bot token or backend secrets included
- Only public-facing manifest, agent profile, and packaging workflow committed

## Publish path

After merge to , the docs sync will publish this into the EconomyOS Showcase in  if the repo  is configured.