### PR TITLE
Add reversible Virtuals config switchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ Path: [`utilities/model-routing/claude-virtuals-router`](utilities/model-routing
 
 This setup example lets Claude Code use Virtuals-hosted models through `claude-code-router`.
 
+Use `scripts/configure-claude-virtuals.mjs virtuals` from the repo root to activate the Claude Code Router provider, `scripts/configure-claude-virtuals.mjs restore` to switch back to the previous router provider/routes, or `scripts/configure-claude-virtuals.mjs default` to remove the Virtuals routes when no restore state exists. Restart `claude-code-router` after changing the config.
+
 ## Use The Skill
 
 ### ACP Paid Subscription Checkout

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ Path: [`utilities/model-routing/codex-virtuals-proxy`](utilities/model-routing/c
 
 This local helper lets Codex use Virtuals-hosted models by translating Codex Responses API calls to the Virtuals Chat Completions endpoint.
 
+Use `scripts/configure-codex-virtuals.mjs virtuals` from the repo root to activate the Codex provider block, `scripts/configure-codex-virtuals.mjs restore` to switch back to the previous Codex model/provider, or `scripts/configure-codex-virtuals.mjs default` to switch back to built-in Codex routing when no restore state exists.
+
 ### Claude Virtuals Router
 
 Path: [`utilities/model-routing/claude-virtuals-router`](utilities/model-routing/claude-virtuals-router)

--- a/docs/agent-setup.md
+++ b/docs/agent-setup.md
@@ -39,6 +39,24 @@ Codex and Claude Code need different local routing surfaces when using Virtuals-
 - Codex custom providers call `/v1/responses`; use [`utilities/model-routing/codex-virtuals-proxy`](../utilities/model-routing/codex-virtuals-proxy).
 - Claude Code calls Anthropic-compatible `/v1/messages`; use [`utilities/model-routing/claude-virtuals-router`](../utilities/model-routing/claude-virtuals-router) with `claude-code-router`.
 
+For Codex, use the config helper instead of hand-editing `~/.codex/config.toml`:
+
+```bash
+scripts/configure-codex-virtuals.mjs virtuals
+```
+
+It records the previous active Codex model/provider and can restore it after the demo:
+
+```bash
+scripts/configure-codex-virtuals.mjs restore
+```
+
+If no restore state exists, switch back to built-in Codex routing:
+
+```bash
+scripts/configure-codex-virtuals.mjs default
+```
+
 Keep shared utilities in `utilities/` so setup docs, skills, and examples evolve together.
 
 ## Desktop Support Matrix

--- a/docs/agent-setup.md
+++ b/docs/agent-setup.md
@@ -57,6 +57,30 @@ If no restore state exists, switch back to built-in Codex routing:
 scripts/configure-codex-virtuals.mjs default
 ```
 
+For Claude Code, use the router config helper instead of hand-editing `~/.claude-code-router/config.json`:
+
+```bash
+scripts/configure-claude-virtuals.mjs virtuals
+```
+
+It records the previous `claude-code-router` provider and route values and can restore them after the demo:
+
+```bash
+scripts/configure-claude-virtuals.mjs restore
+```
+
+If no restore state exists, remove the Virtuals provider and Virtuals routes:
+
+```bash
+scripts/configure-claude-virtuals.mjs default
+```
+
+Validate the active router config before starting Claude Code:
+
+```bash
+scripts/configure-claude-virtuals.mjs check
+```
+
 Keep shared utilities in `utilities/` so setup docs, skills, and examples evolve together.
 
 ## Desktop Support Matrix

--- a/scripts/configure-claude-virtuals.mjs
+++ b/scripts/configure-claude-virtuals.mjs
@@ -1,0 +1,420 @@
+#!/usr/bin/env node
+
+import { existsSync, mkdirSync, readFileSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+
+const DEFAULT_PROVIDER = "virtuals";
+const DEFAULT_API_BASE_URL = "https://compute.virtuals.io/v1/chat/completions";
+const DEFAULT_API_KEY = "$VIRTUALS_API_KEY";
+const DEFAULT_MODELS = [
+  "openai-gpt-55",
+  "openai-gpt-55-pro",
+  "openai-gpt-54-mini",
+  "claude-opus-4-7-fast",
+  "claude-opus-4-8",
+];
+const DEFAULT_MODEL = "claude-opus-4-7-fast";
+const DEFAULT_THINK_MODEL = "claude-opus-4-8";
+const ROUTER_KEYS = ["default", "background", "think", "longContext"];
+
+const options = parseArgs(process.argv.slice(2));
+const configPath = expandPath(options.config || "~/.claude-code-router/config.json");
+const statePath = `${configPath}.virtuals-state.json`;
+const backupPath = `${configPath}.before-virtuals.bak`;
+
+if (options.help) {
+  usage();
+  process.exit(0);
+}
+
+if (options.mode === "restore") {
+  restoreConfig();
+} else if (options.mode === "default") {
+  switchToDefaultClaudeCode();
+} else if (options.mode === "check") {
+  checkConfig();
+} else {
+  configureConfig();
+}
+
+function usage() {
+  console.log(`Usage: scripts/configure-claude-virtuals.mjs [virtuals|restore|default|check] [options]
+
+Activates, checks, or restores Claude Code Router config for Virtuals Chat Completions.
+
+Commands:
+  virtuals                   Switch claude-code-router to Virtuals (default)
+  restore                    Restore the pre-Virtuals provider and router routes
+  default                    Remove the Virtuals provider/routes when no restore state exists
+  check                      Validate the active claude-code-router Virtuals config
+
+Options:
+  --config PATH              Claude Code Router config path (default: ~/.claude-code-router/config.json)
+  --provider NAME            Provider name (default: ${DEFAULT_PROVIDER})
+  --api-base-url URL         Virtuals chat completions URL (default: ${DEFAULT_API_BASE_URL})
+  --api-key VALUE            API key value or env reference (default: ${DEFAULT_API_KEY})
+  --model MODEL              Default/background route model (default: ${DEFAULT_MODEL})
+  --think-model MODEL        Think/long-context route model (default: ${DEFAULT_THINK_MODEL})
+  --models LIST              Comma-separated provider model list
+  --default                  Alias for the default command
+  --restore                  Restore the pre-Virtuals config
+  -h, --help                 Show this help
+`);
+}
+
+function parseArgs(args) {
+  const parsed = {
+    mode: "virtuals",
+    help: false,
+    config: undefined,
+    provider: DEFAULT_PROVIDER,
+    apiBaseUrl: DEFAULT_API_BASE_URL,
+    apiKey: DEFAULT_API_KEY,
+    model: DEFAULT_MODEL,
+    thinkModel: DEFAULT_THINK_MODEL,
+    models: DEFAULT_MODELS,
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    switch (arg) {
+      case "virtuals":
+      case "restore":
+      case "default":
+      case "check":
+        parsed.mode = arg;
+        break;
+      case "--config":
+        parsed.config = requiredValue(args, (index += 1), arg);
+        break;
+      case "--provider":
+        parsed.provider = requiredValue(args, (index += 1), arg);
+        break;
+      case "--api-base-url":
+        parsed.apiBaseUrl = requiredValue(args, (index += 1), arg);
+        break;
+      case "--api-key":
+        parsed.apiKey = requiredValue(args, (index += 1), arg);
+        break;
+      case "--model":
+        parsed.model = requiredValue(args, (index += 1), arg);
+        break;
+      case "--think-model":
+        parsed.thinkModel = requiredValue(args, (index += 1), arg);
+        break;
+      case "--models":
+        parsed.models = requiredValue(args, (index += 1), arg)
+          .split(",")
+          .map((model) => model.trim())
+          .filter(Boolean);
+        if (parsed.models.length === 0) fail("--models must include at least one model");
+        break;
+      case "--default":
+        parsed.mode = "default";
+        break;
+      case "--restore":
+        parsed.mode = "restore";
+        break;
+      case "-h":
+      case "--help":
+        parsed.help = true;
+        break;
+      default:
+        fail(`Unknown argument: ${arg}`);
+    }
+  }
+
+  assertProviderName(parsed.provider);
+  return parsed;
+}
+
+function requiredValue(args, index, flag) {
+  const value = args[index];
+  if (!value || value.startsWith("--")) {
+    fail(`Missing value for ${flag}`);
+  }
+  return value;
+}
+
+function fail(message) {
+  console.error(message);
+  process.exit(1);
+}
+
+function expandPath(path) {
+  if (path === "~") return process.env.HOME;
+  if (path.startsWith("~/")) return join(process.env.HOME, path.slice(2));
+  return resolve(path);
+}
+
+function assertProviderName(value) {
+  if (!/^[A-Za-z0-9_-]+$/.test(value)) {
+    fail("--provider must contain only letters, numbers, underscores, or dashes");
+  }
+}
+
+function readConfigText() {
+  return existsSync(configPath) ? readFileSync(configPath, "utf8") : "";
+}
+
+function readConfig() {
+  const text = readConfigText();
+  if (!text.trim()) return {};
+
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    fail(`Could not parse ${configPath}: ${error.message}`);
+  }
+}
+
+function writeConfig(config) {
+  mkdirSync(dirname(configPath), { recursive: true });
+  writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`, { mode: 0o600 });
+}
+
+function configureConfig() {
+  const originalText = readConfigText();
+  const originalConfig = readConfig();
+  const next = clone(originalConfig);
+
+  writeStateIfMissing(originalText, originalConfig);
+  next.Providers = upsertProvider(next.Providers, providerConfig());
+  next.Router = {
+    ...(next.Router && typeof next.Router === "object" ? next.Router : {}),
+    default: route(options.model),
+    background: route(options.model),
+    think: route(options.thinkModel),
+    longContext: route(options.thinkModel),
+  };
+
+  if (JSON.stringify(next) === JSON.stringify(originalConfig)) {
+    console.log(`Claude Code Router config already routes through ${options.provider}.`);
+    return;
+  }
+
+  writeBackupIfMissing(originalText);
+  writeConfig(next);
+  console.log(`Updated ${configPath}`);
+  console.log(`Active default route: ${route(options.model)}`);
+  console.log(`Active think route: ${route(options.thinkModel)}`);
+  console.log(`Restore with: scripts/configure-claude-virtuals.mjs restore`);
+  console.log(`Restart claude-code-router with: ccr restart`);
+}
+
+function restoreConfig() {
+  if (!existsSync(statePath)) {
+    fail(
+      `No Virtuals state file found at ${statePath}. Use "scripts/configure-claude-virtuals.mjs default" to remove Virtuals routes.`,
+    );
+  }
+
+  const state = JSON.parse(readFileSync(statePath, "utf8"));
+  const currentText = readConfigText();
+  const current = readConfig();
+  const next = clone(current);
+
+  restoreProvider(next, state);
+  restoreRouter(next, state);
+  cleanupEmptyContainers(next, state);
+
+  if (!state.hadConfig && isEmptyConfig(next)) {
+    if (existsSync(configPath)) unlinkSync(configPath);
+  } else if (JSON.stringify(next) !== JSON.stringify(current)) {
+    writeBackupIfMissing(currentText);
+    writeConfig(next);
+  }
+
+  rmSync(statePath, { force: true });
+  console.log(`Restored Claude Code Router config from ${statePath}`);
+  console.log(`Restart claude-code-router with: ccr restart`);
+}
+
+function switchToDefaultClaudeCode() {
+  const originalText = readConfigText();
+  const original = readConfig();
+  const next = clone(original);
+
+  removeProvider(next, options.provider);
+  removeVirtualsRoutes(next, options.provider);
+  cleanupEmptyContainers(next, { hadProviders: Boolean(original.Providers), hadRouter: Boolean(original.Router) });
+
+  if (existsSync(configPath) && JSON.stringify(next) !== JSON.stringify(original)) {
+    writeBackupIfMissing(originalText);
+    writeConfig(next);
+  }
+
+  rmSync(statePath, { force: true });
+  console.log(`Removed ${options.provider} routes from Claude Code Router config.`);
+  console.log("Use plain `claude` for built-in Claude Code routing, or restart ccr before using another ccr config.");
+}
+
+function checkConfig() {
+  const config = readConfig();
+  const provider = findProvider(config.Providers, options.provider);
+  const errors = [];
+  const warnings = [];
+
+  if (!provider) {
+    errors.push(`Missing provider "${options.provider}"`);
+  } else {
+    if (provider.api_base_url !== options.apiBaseUrl) {
+      warnings.push(`Provider api_base_url is ${provider.api_base_url || "<missing>"}`);
+    }
+    if (!provider.api_key) {
+      errors.push(`Provider "${options.provider}" is missing api_key`);
+    } else {
+      const envReference = parseEnvReference(provider.api_key);
+      if (envReference && !process.env[envReference]) {
+        errors.push(`${envReference} is not set in the current shell`);
+      }
+    }
+    const transformers = provider.transformer?.use || [];
+    if (!transformers.includes("cleancache")) {
+      errors.push('Provider transformer must include "cleancache" for Claude Code prompt-cache metadata');
+    }
+    if (!transformers.includes("anthropic")) {
+      warnings.push('Provider transformer should include "anthropic" for Claude Code Router compatibility');
+    }
+  }
+
+  for (const key of ROUTER_KEYS) {
+    const value = config.Router?.[key];
+    if (typeof value !== "string" || !value.startsWith(`${options.provider},`)) {
+      warnings.push(`Router.${key} is not routed through ${options.provider}`);
+    }
+  }
+
+  if (errors.length) {
+    for (const error of errors) console.error(`ERROR: ${error}`);
+    for (const warning of warnings) console.error(`WARN: ${warning}`);
+    process.exit(1);
+  }
+
+  for (const warning of warnings) console.warn(`WARN: ${warning}`);
+  console.log(`Claude Code Router Virtuals config looks usable at ${configPath}`);
+}
+
+function providerConfig() {
+  return {
+    name: options.provider,
+    api_base_url: options.apiBaseUrl,
+    api_key: options.apiKey,
+    models: unique([...options.models, options.model, options.thinkModel]),
+    transformer: {
+      use: ["anthropic", "cleancache"],
+    },
+  };
+}
+
+function route(model) {
+  return `${options.provider},${model}`;
+}
+
+function writeStateIfMissing(originalText, originalConfig) {
+  if (existsSync(statePath)) return;
+
+  const provider = findProvider(originalConfig.Providers, options.provider);
+  const router = originalConfig.Router && typeof originalConfig.Router === "object" ? originalConfig.Router : {};
+  const state = {
+    createdAt: new Date().toISOString(),
+    provider: options.provider,
+    hadConfig: Boolean(originalText.trim()),
+    hadProviders: Array.isArray(originalConfig.Providers),
+    providerConfig: provider ? clone(provider) : null,
+    hadRouter: Boolean(originalConfig.Router && typeof originalConfig.Router === "object"),
+    routes: Object.fromEntries(
+      ROUTER_KEYS.map((key) => [
+        key,
+        {
+          had: Object.prototype.hasOwnProperty.call(router, key),
+          value: router[key],
+        },
+      ]),
+    ),
+  };
+
+  mkdirSync(dirname(statePath), { recursive: true });
+  writeFileSync(statePath, `${JSON.stringify(state, null, 2)}\n`, { mode: 0o600 });
+}
+
+function writeBackupIfMissing(text) {
+  if (!text || existsSync(backupPath)) return;
+  writeFileSync(backupPath, ensureTrailingNewline(text), { mode: 0o600 });
+}
+
+function upsertProvider(providers, provider) {
+  const next = Array.isArray(providers) ? providers.filter((item) => item?.name !== provider.name) : [];
+  next.push(provider);
+  return next;
+}
+
+function restoreProvider(config, state) {
+  if (state.providerConfig) {
+    config.Providers = upsertProvider(config.Providers, state.providerConfig);
+  } else {
+    removeProvider(config, state.provider || options.provider);
+  }
+}
+
+function removeProvider(config, providerName) {
+  if (!Array.isArray(config.Providers)) return;
+  config.Providers = config.Providers.filter((provider) => provider?.name !== providerName);
+}
+
+function restoreRouter(config, state) {
+  if (!config.Router || typeof config.Router !== "object") config.Router = {};
+
+  for (const key of ROUTER_KEYS) {
+    const routeState = state.routes?.[key];
+    if (routeState?.had) {
+      config.Router[key] = routeState.value;
+    } else {
+      delete config.Router[key];
+    }
+  }
+}
+
+function removeVirtualsRoutes(config, providerName) {
+  if (!config.Router || typeof config.Router !== "object") return;
+  for (const [key, value] of Object.entries(config.Router)) {
+    if (typeof value === "string" && value.startsWith(`${providerName},`)) {
+      delete config.Router[key];
+    }
+  }
+}
+
+function cleanupEmptyContainers(config, state) {
+  if (Array.isArray(config.Providers) && config.Providers.length === 0 && !state.hadProviders) {
+    delete config.Providers;
+  }
+
+  if (config.Router && typeof config.Router === "object" && Object.keys(config.Router).length === 0 && !state.hadRouter) {
+    delete config.Router;
+  }
+}
+
+function findProvider(providers, name) {
+  return Array.isArray(providers) ? providers.find((provider) => provider?.name === name) : undefined;
+}
+
+function isEmptyConfig(config) {
+  return Object.keys(config).length === 0;
+}
+
+function clone(value) {
+  return JSON.parse(JSON.stringify(value ?? {}));
+}
+
+function unique(values) {
+  return [...new Set(values)];
+}
+
+function parseEnvReference(value) {
+  const match = String(value).match(/^\$(?:\{([A-Za-z_][A-Za-z0-9_]*)\}|([A-Za-z_][A-Za-z0-9_]*))$/);
+  return match ? match[1] || match[2] : null;
+}
+
+function ensureTrailingNewline(text) {
+  return text.endsWith("\n") ? text : `${text}\n`;
+}

--- a/scripts/configure-codex-virtuals.mjs
+++ b/scripts/configure-codex-virtuals.mjs
@@ -1,0 +1,427 @@
+#!/usr/bin/env node
+
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+
+const DEFAULT_PROVIDER = "virtuals_proxy";
+const DEFAULT_MODEL = "openai-gpt-55";
+const DEFAULT_CODEX_MODEL = "gpt-5.5";
+const DEFAULT_BASE_URL = "http://127.0.0.1:8787/v1";
+
+const options = parseArgs(process.argv.slice(2));
+const configPath = expandPath(options.config || "~/.codex/config.toml");
+const statePath = `${configPath}.virtuals-state.json`;
+const backupPath = `${configPath}.before-virtuals.bak`;
+
+if (options.help) {
+  usage();
+  process.exit(0);
+}
+
+if (options.mode === "restore") {
+  restoreConfig();
+} else if (options.mode === "default") {
+  switchToDefaultCodex();
+} else {
+  configureConfig();
+}
+
+function usage() {
+  console.log(`Usage: scripts/configure-codex-virtuals.mjs [virtuals|restore|default] [options]
+
+Activates or restores Codex model routing through the local Virtuals Responses proxy.
+
+Commands:
+  virtuals              Switch Codex to the local Virtuals proxy (default)
+  restore               Restore the pre-Virtuals active model/provider
+  default               Switch Codex back to built-in provider routing
+
+Options:
+  --config PATH          Codex config path (default: ~/.codex/config.toml)
+  --model MODEL          Virtuals model id (default: ${DEFAULT_MODEL})
+  --default-model MODEL  Built-in Codex model for default mode (default: ${DEFAULT_CODEX_MODEL})
+  --provider NAME        Codex provider name (default: ${DEFAULT_PROVIDER})
+  --base-url URL         Local proxy base URL (default: ${DEFAULT_BASE_URL})
+  --env-key NAME         Optional env var name for local proxy auth
+  --add-provider-only    Add/update the provider block without switching model/provider
+  --default              Alias for the default command
+  --restore              Restore the pre-Virtuals active model/provider
+  -h, --help             Show this help
+`);
+}
+
+function parseArgs(args) {
+  const parsed = {
+    provider: DEFAULT_PROVIDER,
+    model: DEFAULT_MODEL,
+    defaultModel: DEFAULT_CODEX_MODEL,
+    baseUrl: DEFAULT_BASE_URL,
+    envKey: undefined,
+    addProviderOnly: false,
+    mode: "virtuals",
+    help: false,
+    config: undefined,
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    switch (arg) {
+      case "virtuals":
+      case "restore":
+      case "default":
+        parsed.mode = arg;
+        break;
+      case "--config":
+        parsed.config = requiredValue(args, (index += 1), arg);
+        break;
+      case "--model":
+        parsed.model = requiredValue(args, (index += 1), arg);
+        break;
+      case "--default-model":
+        parsed.defaultModel = requiredValue(args, (index += 1), arg);
+        break;
+      case "--provider":
+        parsed.provider = requiredValue(args, (index += 1), arg);
+        break;
+      case "--base-url":
+        parsed.baseUrl = requiredValue(args, (index += 1), arg);
+        break;
+      case "--env-key":
+        parsed.envKey = requiredValue(args, (index += 1), arg);
+        break;
+      case "--add-provider-only":
+        parsed.addProviderOnly = true;
+        break;
+      case "--default":
+        parsed.mode = "default";
+        break;
+      case "--restore":
+        parsed.mode = "restore";
+        break;
+      case "-h":
+      case "--help":
+        parsed.help = true;
+        break;
+      default:
+        fail(`Unknown argument: ${arg}`);
+    }
+  }
+
+  assertBareKey(parsed.provider, "--provider");
+  if (parsed.envKey) assertEnvKey(parsed.envKey);
+  return parsed;
+}
+
+function requiredValue(args, index, flag) {
+  const value = args[index];
+  if (!value || value.startsWith("--")) {
+    fail(`Missing value for ${flag}`);
+  }
+  return value;
+}
+
+function fail(message) {
+  console.error(message);
+  process.exit(1);
+}
+
+function expandPath(path) {
+  if (path === "~") return process.env.HOME;
+  if (path.startsWith("~/")) return join(process.env.HOME, path.slice(2));
+  return resolve(path);
+}
+
+function assertBareKey(value, flag) {
+  if (!/^[A-Za-z0-9_-]+$/.test(value)) {
+    fail(`${flag} must be a TOML bare key: letters, numbers, underscores, or dashes`);
+  }
+}
+
+function assertEnvKey(value) {
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(value)) {
+    fail("--env-key must be a valid environment variable name");
+  }
+}
+
+function readConfig() {
+  return existsSync(configPath) ? readFileSync(configPath, "utf8") : "";
+}
+
+function writeConfig(next) {
+  mkdirSync(dirname(configPath), { recursive: true });
+  writeFileSync(configPath, ensureTrailingNewline(next), { mode: 0o600 });
+}
+
+function configureConfig() {
+  const original = readConfig();
+  let next = original;
+
+  if (!options.addProviderOnly) {
+    writeStateIfMissing(original);
+    next = setTopLevelKey(next, "model", options.model);
+    next = setTopLevelKey(next, "model_provider", options.provider);
+  }
+
+  next = upsertProviderBlock(next, options.provider, providerBlock());
+  if (next === original) {
+    console.log(`Codex config already routes through ${options.provider}.`);
+    return;
+  }
+
+  writeBackupIfMissing(original);
+  writeConfig(next);
+  console.log(`Updated ${configPath}`);
+  if (!options.addProviderOnly) {
+    console.log(`Active model: ${options.model}`);
+    console.log(`Active provider: ${options.provider}`);
+    console.log(`Restore with: scripts/configure-codex-virtuals.mjs restore`);
+  }
+}
+
+function restoreConfig() {
+  if (!existsSync(statePath)) {
+    fail(
+      `No Virtuals state file found at ${statePath}. Use "scripts/configure-codex-virtuals.mjs default" to switch back to built-in Codex routing.`,
+    );
+  }
+
+  const state = JSON.parse(readFileSync(statePath, "utf8"));
+  const original = readConfig();
+  let next = original;
+  const provider = state.provider || options.provider;
+
+  next =
+    state.providerBlock == null
+      ? removeSection(next, providerSectionName(provider))
+      : upsertProviderBlock(next, provider, state.providerBlock);
+
+  next = state.hadModel
+    ? setTopLevelKey(next, "model", state.model)
+    : removeTopLevelKey(next, "model");
+  next = state.hadModelProvider
+    ? setTopLevelKey(next, "model_provider", state.modelProvider)
+    : removeTopLevelKey(next, "model_provider");
+
+  if (state.hadModelCatalogJson) {
+    next = setTopLevelKey(next, "model_catalog_json", state.modelCatalogJson);
+  } else {
+    next = removeTopLevelKey(next, "model_catalog_json");
+  }
+
+  if (next !== original) {
+    writeBackupIfMissing(original);
+    writeConfig(next);
+  }
+
+  rmSync(statePath, { force: true });
+  console.log(`Restored Codex config from ${statePath}`);
+}
+
+function switchToDefaultCodex() {
+  const original = readConfig();
+  let next = original;
+
+  next = removeSection(next, providerSectionName(options.provider));
+  next = setTopLevelKey(next, "model", options.defaultModel);
+  next = removeTopLevelKey(next, "model_provider");
+  next = removeTopLevelKey(next, "model_catalog_json");
+
+  if (next !== original) {
+    writeBackupIfMissing(original);
+    writeConfig(next);
+  }
+
+  rmSync(statePath, { force: true });
+  console.log(`Switched Codex back to built-in provider routing with model ${options.defaultModel}.`);
+}
+
+function writeStateIfMissing(text) {
+  if (existsSync(statePath)) return;
+
+  const provider = options.provider;
+  const state = {
+    createdAt: new Date().toISOString(),
+    provider,
+    hadModel: hasTopLevelKey(text, "model"),
+    model: getTopLevelValue(text, "model"),
+    hadModelProvider: hasTopLevelKey(text, "model_provider"),
+    modelProvider: getTopLevelValue(text, "model_provider"),
+    hadModelCatalogJson: hasTopLevelKey(text, "model_catalog_json"),
+    modelCatalogJson: getTopLevelValue(text, "model_catalog_json"),
+    providerBlock: extractSection(text, providerSectionName(provider)),
+  };
+
+  mkdirSync(dirname(statePath), { recursive: true });
+  writeFileSync(statePath, `${JSON.stringify(state, null, 2)}\n`, { mode: 0o600 });
+}
+
+function writeBackupIfMissing(text) {
+  if (!text || existsSync(backupPath)) return;
+  writeFileSync(backupPath, ensureTrailingNewline(text), { mode: 0o600 });
+}
+
+function providerBlock() {
+  const lines = [
+    `[${providerSectionName(options.provider)}]`,
+    `name = ${tomlString("Virtuals via local Responses proxy")}`,
+    `base_url = ${tomlString(options.baseUrl)}`,
+    `wire_api = "responses"`,
+  ];
+
+  if (options.envKey) {
+    lines.push(`env_key = ${tomlString(options.envKey)}`);
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+function providerSectionName(provider) {
+  return `model_providers.${provider}`;
+}
+
+function tomlString(value) {
+  return JSON.stringify(value);
+}
+
+function ensureTrailingNewline(text) {
+  return text.endsWith("\n") ? text : `${text}\n`;
+}
+
+function splitLines(text) {
+  return ensureTrailingNewline(text).split("\n").slice(0, -1);
+}
+
+function setTopLevelKey(text, key, value) {
+  const lines = splitLines(text);
+  const keyPattern = new RegExp(`^\\s*${escapeRegExp(key)}\\s*=`);
+  const commentedKeyPattern = new RegExp(`^\\s*#\\s*${escapeRegExp(key)}\\s*=`);
+  let inRoot = true;
+  let firstSectionIndex = lines.length;
+  let updated = false;
+  const next = [];
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    if (isSectionHeader(line)) {
+      inRoot = false;
+      firstSectionIndex = Math.min(firstSectionIndex, index);
+    }
+
+    if (inRoot && keyPattern.test(line)) {
+      next.push(`${key} = ${tomlString(value)}`);
+      updated = true;
+      continue;
+    }
+
+    if (inRoot && commentedKeyPattern.test(line)) {
+      if (!updated) {
+        next.push(`${key} = ${tomlString(value)}`);
+        updated = true;
+      }
+      continue;
+    }
+
+    next.push(line);
+  }
+
+  if (!updated) {
+    next.splice(firstSectionIndex, 0, `${key} = ${tomlString(value)}`);
+  }
+
+  return `${next.join("\n")}\n`;
+}
+
+function removeTopLevelKey(text, key) {
+  const keyPattern = new RegExp(`^\\s*${escapeRegExp(key)}\\s*=`);
+  const commentedKeyPattern = new RegExp(`^\\s*#\\s*${escapeRegExp(key)}\\s*=`);
+  const lines = splitLines(text);
+  let inRoot = true;
+  const next = [];
+
+  for (const line of lines) {
+    if (isSectionHeader(line)) inRoot = false;
+    if (inRoot && (keyPattern.test(line) || commentedKeyPattern.test(line))) continue;
+    next.push(line);
+  }
+
+  return `${next.join("\n")}\n`;
+}
+
+function hasTopLevelKey(text, key) {
+  return getTopLevelValue(text, key) != null;
+}
+
+function getTopLevelValue(text, key) {
+  const keyPattern = new RegExp(`^\\s*${escapeRegExp(key)}\\s*=\\s*(.+?)\\s*$`);
+  let inRoot = true;
+
+  for (const line of splitLines(text)) {
+    if (isSectionHeader(line)) inRoot = false;
+    if (!inRoot) continue;
+
+    const match = line.match(keyPattern);
+    if (!match) continue;
+    return parseTomlString(match[1]);
+  }
+
+  return undefined;
+}
+
+function parseTomlString(value) {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value.replace(/^['"]|['"]$/g, "");
+  }
+}
+
+function upsertProviderBlock(text, provider, block) {
+  const withoutBlock = removeSection(text, providerSectionName(provider)).replace(/\n{3,}$/g, "\n\n");
+  return `${withoutBlock.trimEnd()}\n\n${block}`;
+}
+
+function extractSection(text, sectionName) {
+  const lines = splitLines(text);
+  const start = findSectionStart(lines, sectionName);
+  if (start === -1) return null;
+
+  let end = lines.length;
+  for (let index = start + 1; index < lines.length; index += 1) {
+    if (isSectionHeader(lines[index])) {
+      end = index;
+      break;
+    }
+  }
+
+  return `${lines.slice(start, end).join("\n")}\n`;
+}
+
+function removeSection(text, sectionName) {
+  const lines = splitLines(text);
+  const start = findSectionStart(lines, sectionName);
+  if (start === -1) return ensureTrailingNewline(text);
+
+  let end = lines.length;
+  for (let index = start + 1; index < lines.length; index += 1) {
+    if (isSectionHeader(lines[index])) {
+      end = index;
+      break;
+    }
+  }
+
+  lines.splice(start, end - start);
+  return `${lines.join("\n")}\n`;
+}
+
+function findSectionStart(lines, sectionName) {
+  const header = `[${sectionName}]`;
+  return lines.findIndex((line) => line.trim() === header);
+}
+
+function isSectionHeader(line) {
+  return /^\s*\[[^\]]+\]\s*$/.test(line);
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/skills/acp-builder-setup/SKILL.md
+++ b/skills/acp-builder-setup/SKILL.md
@@ -41,9 +41,19 @@ In Claude Desktop, the combined checkout skill must use handoff or evidence-revi
 
 Codex and Claude Code need different local routing utilities:
 
-- Codex: run `utilities/model-routing/codex-virtuals-proxy`, then point `~/.codex/config.toml` at `http://127.0.0.1:8787/v1`.
+- Codex: run `utilities/model-routing/codex-virtuals-proxy`, then use `scripts/configure-codex-virtuals.mjs virtuals` from the repo root to point `~/.codex/config.toml` at `http://127.0.0.1:8787/v1`.
 - Claude Code: use `utilities/model-routing/claude-virtuals-router/config.example.json` with `claude-code-router`.
 - Claude Desktop: do not claim the local router works. Desktop does not inherit `ccr code` or Codex proxy settings.
+
+### Codex Config Switching
+
+Use the helper instead of manually editing `~/.codex/config.toml`:
+
+- Switch Codex to the Virtuals proxy: `scripts/configure-codex-virtuals.mjs virtuals`
+- Switch back to the exact previous Codex model/provider: `scripts/configure-codex-virtuals.mjs restore`
+- If no restore state exists, switch back to built-in Codex routing: `scripts/configure-codex-virtuals.mjs default`
+
+After switching config, start a fresh Codex CLI or Codex Desktop local thread so it picks up the updated provider. Do not stop a proxy that an active Codex thread is still using.
 
 ## Environment Checks
 

--- a/skills/acp-builder-setup/SKILL.md
+++ b/skills/acp-builder-setup/SKILL.md
@@ -42,7 +42,7 @@ In Claude Desktop, the combined checkout skill must use handoff or evidence-revi
 Codex and Claude Code need different local routing utilities:
 
 - Codex: run `utilities/model-routing/codex-virtuals-proxy`, then use `scripts/configure-codex-virtuals.mjs virtuals` from the repo root to point `~/.codex/config.toml` at `http://127.0.0.1:8787/v1`.
-- Claude Code: use `utilities/model-routing/claude-virtuals-router/config.example.json` with `claude-code-router`.
+- Claude Code: use `scripts/configure-claude-virtuals.mjs virtuals` from the repo root to point `~/.claude-code-router/config.json` at Virtuals through `claude-code-router`.
 - Claude Desktop: do not claim the local router works. Desktop does not inherit `ccr code` or Codex proxy settings.
 
 ### Codex Config Switching
@@ -54,6 +54,17 @@ Use the helper instead of manually editing `~/.codex/config.toml`:
 - If no restore state exists, switch back to built-in Codex routing: `scripts/configure-codex-virtuals.mjs default`
 
 After switching config, start a fresh Codex CLI or Codex Desktop local thread so it picks up the updated provider. Do not stop a proxy that an active Codex thread is still using.
+
+### Claude Code Config Switching
+
+Use the helper instead of manually editing `~/.claude-code-router/config.json`:
+
+- Switch Claude Code Router to Virtuals: `scripts/configure-claude-virtuals.mjs virtuals`
+- Check the active router config: `scripts/configure-claude-virtuals.mjs check`
+- Switch back to the previous Claude Code Router provider/routes: `scripts/configure-claude-virtuals.mjs restore`
+- If no restore state exists, remove Virtuals provider/routes: `scripts/configure-claude-virtuals.mjs default`
+
+After switching config, restart the router with `ccr restart` before launching `ccr code`. The Virtuals provider must include the `cleancache` transformer because Claude Code adds Anthropic prompt-cache metadata that Virtuals Chat Completions can reject.
 
 ## Environment Checks
 

--- a/skills/acp-builder-setup/references/setup-commands.md
+++ b/skills/acp-builder-setup/references/setup-commands.md
@@ -17,10 +17,17 @@ scripts/install-local-skills.sh --mode copy --target both
 ```bash
 cd utilities/model-routing/codex-virtuals-proxy
 cp .env.example .env
-VIRTUALS_API_KEY=... npm start
+# edit .env and set VIRTUALS_API_KEY
+npm start
 ```
 
-Add to `~/.codex/config.toml`:
+In another terminal from the repo root, activate Codex routing through the local proxy:
+
+```bash
+scripts/configure-codex-virtuals.mjs virtuals
+```
+
+This updates `~/.codex/config.toml` to use:
 
 ```toml
 model = "openai-gpt-55"
@@ -30,6 +37,18 @@ model_provider = "virtuals_proxy"
 name = "Virtuals via local Responses proxy"
 base_url = "http://127.0.0.1:8787/v1"
 wire_api = "responses"
+```
+
+Restore the previous Codex model/provider after the demo:
+
+```bash
+scripts/configure-codex-virtuals.mjs restore
+```
+
+If no restore state exists, switch back to built-in Codex routing:
+
+```bash
+scripts/configure-codex-virtuals.mjs default
 ```
 
 ## Claude Code Virtuals Router

--- a/skills/acp-builder-setup/references/setup-commands.md
+++ b/skills/acp-builder-setup/references/setup-commands.md
@@ -57,12 +57,25 @@ scripts/configure-codex-virtuals.mjs default
 npm install -g @anthropic-ai/claude-code
 npm install -g @musistudio/claude-code-router
 
-mkdir -p "$HOME/.claude-code-router"
-cp utilities/model-routing/claude-virtuals-router/config.example.json \
-  "$HOME/.claude-code-router/config.json"
-
 export VIRTUALS_API_KEY=...
+scripts/configure-claude-virtuals.mjs virtuals
+scripts/configure-claude-virtuals.mjs check
+ccr restart
 ccr code
+```
+
+Restore the previous Claude Code Router provider/routes after the demo:
+
+```bash
+scripts/configure-claude-virtuals.mjs restore
+ccr restart
+```
+
+If no restore state exists, remove the Virtuals provider/routes:
+
+```bash
+scripts/configure-claude-virtuals.mjs default
+ccr restart
 ```
 
 ## Claude Desktop Upload

--- a/utilities/model-routing/claude-virtuals-router/README.md
+++ b/utilities/model-routing/claude-virtuals-router/README.md
@@ -13,24 +13,37 @@ npm install -g @anthropic-ai/claude-code
 npm install -g @musistudio/claude-code-router
 ```
 
-Create the router config:
+Create or update the router config from the repo root:
 
 ```bash
-mkdir -p "$HOME/.claude-code-router"
-cp utilities/model-routing/claude-virtuals-router/config.example.json \
-  "$HOME/.claude-code-router/config.json"
+scripts/configure-claude-virtuals.mjs virtuals
 ```
 
 Set your key in the shell that starts the router:
 
 ```bash
 export VIRTUALS_API_KEY=...
+scripts/configure-claude-virtuals.mjs check
 ccr code
 ```
 
 After editing `~/.claude-code-router/config.json`, restart the router:
 
 ```bash
+ccr restart
+```
+
+Restore the previous router provider and route values after the demo:
+
+```bash
+scripts/configure-claude-virtuals.mjs restore
+ccr restart
+```
+
+If no restore state exists, remove the Virtuals provider and Virtuals routes:
+
+```bash
+scripts/configure-claude-virtuals.mjs default
 ccr restart
 ```
 
@@ -44,4 +57,13 @@ https://compute.virtuals.io/v1/chat/completions
 
 It uses the `anthropic` transformer because Claude Code sends Anthropic-style `/v1/messages` requests, while Virtuals accepts OpenAI-style Chat Completions requests.
 
-The default routes use Claude-family Virtuals models because `claude-code-router` forwards token cap parameters and some Virtuals OpenAI-family models reject those parameters. If you add a transformer that drops token caps, you can route Claude Code to `openai-gpt-55` instead.
+It also uses the `cleancache` transformer. Claude Code adds Anthropic prompt-cache metadata such as `cache_control` to real `ccr code` requests. Direct local router curls can work without that metadata, while `ccr code` can fail with:
+
+```text
+Error from provider(virtuals,claude-opus-4-8: 400):
+{"message":"Failed to perform chat completion: Bad Request"}
+```
+
+In that case, check that the provider transformer chain includes both `anthropic` and `cleancache`, then restart `ccr`.
+
+The default routes use Claude-family Virtuals models because `claude-code-router` forwards large token cap parameters and some Virtuals OpenAI-family models reject those parameters. If you add a transformer that drops token caps, you can route Claude Code to `openai-gpt-55` instead.

--- a/utilities/model-routing/claude-virtuals-router/config.example.json
+++ b/utilities/model-routing/claude-virtuals-router/config.example.json
@@ -16,7 +16,7 @@
         "claude-opus-4-8"
       ],
       "transformer": {
-        "use": ["anthropic"]
+        "use": ["anthropic", "cleancache"]
       }
     }
   ],

--- a/utilities/model-routing/codex-virtuals-proxy/README.md
+++ b/utilities/model-routing/codex-virtuals-proxy/README.md
@@ -13,14 +13,21 @@ Requires Node.js 22 or newer.
 ```bash
 cd utilities/model-routing/codex-virtuals-proxy
 cp .env.example .env
-VIRTUALS_API_KEY=... npm start
+# edit .env and set VIRTUALS_API_KEY
+npm start
 ```
 
 The proxy listens at `http://127.0.0.1:8787/v1` by default.
 
 ## Codex Config
 
-Add this to `~/.codex/config.toml`:
+From the repo root, activate Codex routing through this proxy:
+
+```bash
+scripts/configure-codex-virtuals.mjs virtuals
+```
+
+The script records the previous active Codex model/provider, then updates `~/.codex/config.toml` to use:
 
 ```toml
 model = "openai-gpt-55"
@@ -32,7 +39,19 @@ base_url = "http://127.0.0.1:8787/v1"
 wire_api = "responses"
 ```
 
-If you set `VIRTUALS_PROXY_API_KEY`, also add `env_key = "VIRTUALS_PROXY_API_KEY"` to the provider block and export the same value in the shell that starts Codex.
+Restore the previous Codex model/provider after the demo:
+
+```bash
+scripts/configure-codex-virtuals.mjs restore
+```
+
+If no restore state exists, switch back to built-in Codex routing:
+
+```bash
+scripts/configure-codex-virtuals.mjs default
+```
+
+If you set `VIRTUALS_PROXY_API_KEY`, run `scripts/configure-codex-virtuals.mjs virtuals --env-key VIRTUALS_PROXY_API_KEY` and export the same value in the shell that starts Codex.
 
 ## Environment
 


### PR DESCRIPTION
## Summary

Adds reversible config helpers for switching local Codex and Claude Code workflows into Virtuals-hosted model routing and back out again without hand-editing config files.

## What changed

- Added `scripts/configure-codex-virtuals.mjs` with explicit `virtuals`, `restore`, and `default` modes for `~/.codex/config.toml`.
- Added `scripts/configure-claude-virtuals.mjs` with `virtuals`, `check`, `restore`, and `default` modes for `~/.claude-code-router/config.json`.
- Updated the `acp-builder-setup` skill instructions and setup docs to use the helpers for both Codex and Claude Code.
- Updated the Claude Code Router example to include `cleancache`, which strips Claude Code prompt-cache metadata before requests hit Virtuals Chat Completions.

## Claude 400 diagnosis

The failing `ccr code` path was not the same as a simple direct local router curl. Real Claude Code requests add Anthropic prompt-cache metadata, especially `cache_control` on system prompt blocks. Captured `ccr code` payloads failed against Virtuals as-is with:

```text
{"message":"Failed to perform chat completion: Bad Request"}
```

The same captured payload succeeded after removing `cache_control` from the system message. Removing only user-message cache metadata still failed. The checked-in config now uses the built-in `cleancache` transformer, and the new Claude helper's `check` command fails if that transformer or the referenced API-key env var is missing.

## Validation

- `node --check scripts/configure-codex-virtuals.mjs`
- `node --check scripts/configure-claude-virtuals.mjs`
- Temp config tests for Codex `virtuals`, `restore`, and `default` modes.
- Temp config tests for Claude `virtuals`, `check`, `restore`, `default`, and missing `VIRTUALS_API_KEY` failure.
- Full Codex E2E: temporary `CODEX_HOME`, helper-generated config, local Responses proxy, `/v1/models` health check, and `codex exec` returned `VIRTUALS OK` through Virtuals.
- Full Claude E2E: temporary `HOME`, helper-generated config, `scripts/configure-claude-virtuals.mjs check`, `ccr code --bare -p --permission-mode bypassPermissions` returned `VIRTUALS OK`, then `restore` removed the temporary router config.
- Captured real `ccr code` request body against a local upstream, then replayed it against Virtuals to isolate the reported 400: `as-is` failed, `no-system-cache` succeeded, `no-user-cache` still failed.

## Notes

An unrelated local `utilities/model-routing/codex-virtuals-proxy/server.mjs` change was left unstaged and is not part of this PR.
