### PR TITLE
Fix Codex Virtuals model routing and add model config guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ This example validates that an ACP agent can complete a paid newsletter checkout
 
 Agent setup guide: [`docs/agent-setup.md`](docs/agent-setup.md)
 
+Model selection and configuration: [`docs/model-config.md`](docs/model-config.md)
+
 GitHub skill references: [`docs/skill-packages.md`](docs/skill-packages.md)
 
 Packaged skills: [`packages/`](packages)

--- a/docs/agent-setup.md
+++ b/docs/agent-setup.md
@@ -34,6 +34,8 @@ scripts/install-local-skills.sh --mode copy --target both
 
 ## Model Routing Utilities
 
+To discover available model IDs and choose which model each agent uses, see [`docs/model-config.md`](model-config.md).
+
 Codex and Claude Code need different local routing surfaces when using Virtuals-hosted models:
 
 - Codex custom providers call `/v1/responses`; use [`utilities/model-routing/codex-virtuals-proxy`](../utilities/model-routing/codex-virtuals-proxy).

--- a/docs/model-config.md
+++ b/docs/model-config.md
@@ -1,0 +1,120 @@
+# Choosing and Configuring the Model
+
+Virtuals-hosted models are served from `https://compute.virtuals.io/v1`. The
+model is a configuration parameter, but it lives in a different place for Codex
+versus Claude Code. This guide covers how to discover valid model IDs and where
+to set them. For activating the routing surfaces themselves, see
+[`docs/agent-setup.md`](agent-setup.md).
+
+## 1. Discover available models
+
+The endpoint exposes a live model list. Query it before editing any config so
+you copy an exact, currently-valid `id`:
+
+```bash
+curl -s https://compute.virtuals.io/v1/models \
+  -H "Authorization: Bearer $VIRTUALS_API_KEY" \
+  | jq -r '.data[] | "\(.id)  (\(.contextLength) ctx)"'
+```
+
+The `id` field is the exact string configs expect. Example output:
+
+```
+claude-opus-4-8  (1000000 ctx)
+claude-opus-4-7-fast  (1000000 ctx)
+claude-fable-5  (1000000 ctx)
+deepseek-v4-pro  (1000000 ctx)
+gemini-3-flash-preview  (1000000 ctx)
+venice-uncensored-1-2  (128000 ctx)
+```
+
+The available set changes over time. Treat this endpoint as the source of
+truth, not any model list hard-coded in a README or example config.
+
+## 2. Set the model for Codex
+
+Codex reads `~/.codex/config.toml`. The model is the top-level `model` key,
+which must point at a provider block:
+
+```toml
+model = "claude-opus-4-8"        # any id from step 1
+model_provider = "virtuals_proxy"
+
+[model_providers.virtuals_proxy]
+name = "Virtuals via local Responses proxy"
+base_url = "http://127.0.0.1:8787/v1"
+wire_api = "responses"
+```
+
+Prefer the helper over hand-editing — it preserves and can restore your
+previous model/provider:
+
+```bash
+scripts/configure-codex-virtuals.mjs virtuals   # activate Virtuals routing
+scripts/configure-codex-virtuals.mjs restore    # back to previous model/provider
+scripts/configure-codex-virtuals.mjs default    # back to built-in Codex routing
+```
+
+To change which Virtuals model Codex uses, edit the `model` value in
+`~/.codex/config.toml` to another `id` from step 1, then restart Codex. The
+local proxy in
+[`utilities/model-routing/codex-virtuals-proxy`](../utilities/model-routing/codex-virtuals-proxy)
+must be running.
+
+## 3. Set the model for Claude Code
+
+Claude Code (via `claude-code-router`) reads
+`~/.claude-code-router/config.json`. The model appears in **two** places that
+must agree:
+
+```jsonc
+{
+  "Providers": [{
+    "name": "virtuals",
+    "api_base_url": "https://compute.virtuals.io/v1/chat/completions",
+    "api_key": "$VIRTUALS_API_KEY",
+    "models": [                 // allowlist: a model must be listed here to be usable
+      "claude-opus-4-8",
+      "claude-opus-4-7-fast"
+    ],
+    "transformer": { "use": ["anthropic", "cleancache"] }
+  }],
+  "Router": {                   // which model serves each scenario
+    "default":     "virtuals,claude-opus-4-7-fast",
+    "background":  "virtuals,claude-opus-4-7-fast",
+    "think":       "virtuals,claude-opus-4-8",
+    "longContext": "virtuals,claude-opus-4-8"
+  }
+}
+```
+
+- `Router` values are `"<provider-name>,<model-id>"`.
+- Every model named in `Router` must also appear in that provider's `models[]`.
+- The four `Router` keys let you route cheaper/faster models to background and
+  default work while reserving a stronger model for `think` and `longContext`.
+
+Use the helper rather than hand-editing:
+
+```bash
+scripts/configure-claude-virtuals.mjs virtuals   # activate Virtuals provider + routes
+scripts/configure-claude-virtuals.mjs check      # validate the active config
+scripts/configure-claude-virtuals.mjs restore    # back to previous provider/routes
+scripts/configure-claude-virtuals.mjs default    # remove Virtuals routes
+```
+
+Run `check` before starting Claude Code, then restart the router after any
+config change (`ccr restart`, or `ccr stop && ccr code`).
+
+## 4. Confirm traffic reaches Virtuals
+
+Send a request straight at the endpoint and look for the `venice_parameters`
+object in the response — its presence confirms the request was served by the
+Virtuals compute endpoint:
+
+```bash
+curl -s https://compute.virtuals.io/v1/chat/completions \
+  -H "Authorization: Bearer $VIRTUALS_API_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"claude-opus-4-8","max_tokens":20,
+       "messages":[{"role":"user","content":"reply: VIRTUALS OK"}]}'
+```

--- a/docs/model-config.md
+++ b/docs/model-config.md
@@ -93,10 +93,51 @@ must agree:
 - The four `Router` keys let you route cheaper/faster models to background and
   default work while reserving a stronger model for `think` and `longContext`.
 
-Use the helper rather than hand-editing:
+> **Note:** the router remaps every request to the model in the matching
+> `Router` route, regardless of the model id sent in the request. A request that
+> names `claude-opus-4-8` but matches the `default` route is served by
+> `default`'s model, not the requested one. To run a specific model you must set
+> it on the route that request will hit. Most interactive Claude Code use hits
+> the `default` route.
+
+### Set the model on a route
+
+There are two ways. Either edits the same file —
+`~/.claude-code-router/config.json`.
+
+**Option A — helper flags (preferred).** Run from the repo root. The helper
+writes the routes and keeps `models[]` in sync:
 
 ```bash
-scripts/configure-claude-virtuals.mjs virtuals   # activate Virtuals provider + routes
+# --model sets the default AND background routes
+# --think-model sets the think AND longContext routes
+# --models is the provider allowlist (every routed model must be listed here)
+scripts/configure-claude-virtuals.mjs virtuals \
+  --model claude-opus-4-8 \
+  --think-model claude-opus-4-8 \
+  --models claude-opus-4-8,claude-opus-4-7-fast
+```
+
+**Option B — hand-edit.** Open `~/.claude-code-router/config.json` and change
+the value of the route you want under `Router`. The value format is
+`"<provider-name>,<model-id>"`. To make every interactive request use
+`claude-opus-4-8`:
+
+```jsonc
+"Router": {
+  "default":     "virtuals,claude-opus-4-8",   // <- interactive requests hit this
+  "background":  "virtuals,claude-opus-4-7-fast",
+  "think":       "virtuals,claude-opus-4-8",
+  "longContext": "virtuals,claude-opus-4-8"
+}
+```
+
+Whichever route you edit, the model id must also be present in
+`Providers[].models[]`.
+
+### Other helper commands
+
+```bash
 scripts/configure-claude-virtuals.mjs check      # validate the active config
 scripts/configure-claude-virtuals.mjs restore    # back to previous provider/routes
 scripts/configure-claude-virtuals.mjs default    # remove Virtuals routes

--- a/scripts/configure-claude-virtuals.mjs
+++ b/scripts/configure-claude-virtuals.mjs
@@ -178,7 +178,7 @@ function configureConfig() {
   const originalConfig = readConfig();
   const next = clone(originalConfig);
 
-  writeStateIfMissing(originalText, originalConfig);
+  captureRestoreState(originalText, originalConfig);
   next.Providers = upsertProvider(next.Providers, providerConfig());
   next.Router = {
     ...(next.Router && typeof next.Router === "object" ? next.Router : {}),
@@ -311,9 +311,13 @@ function route(model) {
   return `${options.provider},${model}`;
 }
 
-function writeStateIfMissing(originalText, originalConfig) {
-  if (existsSync(statePath)) return;
-
+function captureRestoreState(originalText, originalConfig) {
+  // Snapshot the config exactly as it is on disk right now, overwriting any
+  // previous snapshot. `restore` then always returns to the state immediately
+  // before the most recent activation. Capturing only once (the old behavior)
+  // left the snapshot stale whenever the config was edited between activations,
+  // so restore silently reverted those edits away. The genuine pre-Virtuals
+  // baseline is preserved separately in `.before-virtuals.bak`.
   const provider = findProvider(originalConfig.Providers, options.provider);
   const router = originalConfig.Router && typeof originalConfig.Router === "object" ? originalConfig.Router : {};
   const state = {

--- a/scripts/configure-codex-virtuals.mjs
+++ b/scripts/configure-codex-virtuals.mjs
@@ -162,7 +162,7 @@ function configureConfig() {
   const model = codexModelId(options.model);
 
   if (!options.addProviderOnly) {
-    writeStateIfMissing(original);
+    captureRestoreState(original);
     next = setTopLevelKey(next, "model", model);
     next = setTopLevelKey(next, "model_provider", options.provider);
   }
@@ -249,9 +249,13 @@ function switchToDefaultCodex() {
   console.log(`Switched Codex back to built-in provider routing with model ${options.defaultModel}.`);
 }
 
-function writeStateIfMissing(text) {
-  if (existsSync(statePath)) return;
-
+function captureRestoreState(text) {
+  // Snapshot the config exactly as it is on disk right now, overwriting any
+  // previous snapshot. `restore` then always returns to the state immediately
+  // before the most recent activation. Capturing only once (the old behavior)
+  // left the snapshot stale whenever the config was edited between activations,
+  // so restore silently reverted those edits away. The genuine pre-Virtuals
+  // baseline is preserved separately in `.before-virtuals.bak`.
   const provider = options.provider;
   const state = {
     createdAt: new Date().toISOString(),

--- a/scripts/configure-codex-virtuals.mjs
+++ b/scripts/configure-codex-virtuals.mjs
@@ -4,9 +4,13 @@ import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node
 import { dirname, join, resolve } from "node:path";
 
 const DEFAULT_PROVIDER = "virtuals_proxy";
-const DEFAULT_MODEL = "openai-gpt-55";
+const DEFAULT_MODEL = "gpt-5.5";
 const DEFAULT_CODEX_MODEL = "gpt-5.5";
 const DEFAULT_BASE_URL = "http://127.0.0.1:8787/v1";
+const LEGACY_VIRTUALS_MODEL_TO_CODEX_MODEL = new Map([
+  ["openai-gpt-55", "gpt-5.5"],
+  ["openai-gpt-54-mini", "gpt-5.4-mini"],
+]);
 
 const options = parseArgs(process.argv.slice(2));
 const configPath = expandPath(options.config || "~/.codex/config.toml");
@@ -38,7 +42,7 @@ Commands:
 
 Options:
   --config PATH          Codex config path (default: ~/.codex/config.toml)
-  --model MODEL          Virtuals model id (default: ${DEFAULT_MODEL})
+  --model MODEL          Codex model id (default: ${DEFAULT_MODEL})
   --default-model MODEL  Built-in Codex model for default mode (default: ${DEFAULT_CODEX_MODEL})
   --provider NAME        Codex provider name (default: ${DEFAULT_PROVIDER})
   --base-url URL         Local proxy base URL (default: ${DEFAULT_BASE_URL})
@@ -155,10 +159,11 @@ function writeConfig(next) {
 function configureConfig() {
   const original = readConfig();
   let next = original;
+  const model = codexModelId(options.model);
 
   if (!options.addProviderOnly) {
     writeStateIfMissing(original);
-    next = setTopLevelKey(next, "model", options.model);
+    next = setTopLevelKey(next, "model", model);
     next = setTopLevelKey(next, "model_provider", options.provider);
   }
 
@@ -172,10 +177,19 @@ function configureConfig() {
   writeConfig(next);
   console.log(`Updated ${configPath}`);
   if (!options.addProviderOnly) {
-    console.log(`Active model: ${options.model}`);
+    if (model !== options.model) {
+      console.log(
+        `Normalized model ${options.model} to Codex-compatible ${model}. The local proxy maps it upstream.`,
+      );
+    }
+    console.log(`Active model: ${model}`);
     console.log(`Active provider: ${options.provider}`);
     console.log(`Restore with: scripts/configure-codex-virtuals.mjs restore`);
   }
+}
+
+function codexModelId(model) {
+  return LEGACY_VIRTUALS_MODEL_TO_CODEX_MODEL.get(model) || model;
 }
 
 function restoreConfig() {

--- a/skills/acp-builder-setup/SKILL.md
+++ b/skills/acp-builder-setup/SKILL.md
@@ -41,7 +41,7 @@ In Claude Desktop, the combined checkout skill must use handoff or evidence-revi
 
 Codex and Claude Code need different local routing utilities:
 
-- Codex: run `utilities/model-routing/codex-virtuals-proxy`, then use `scripts/configure-codex-virtuals.mjs virtuals` from the repo root to point `~/.codex/config.toml` at `http://127.0.0.1:8787/v1`.
+- Codex: run `utilities/model-routing/codex-virtuals-proxy`, then use `scripts/configure-codex-virtuals.mjs virtuals` from the repo root to point `~/.codex/config.toml` at `http://127.0.0.1:8787/v1`. Codex config must use a Codex-supported model id such as `gpt-5.5`; the local proxy maps that to the upstream Virtuals model id.
 - Claude Code: use `scripts/configure-claude-virtuals.mjs virtuals` from the repo root to point `~/.claude-code-router/config.json` at Virtuals through `claude-code-router`.
 - Claude Desktop: do not claim the local router works. Desktop does not inherit `ccr code` or Codex proxy settings.
 

--- a/skills/acp-builder-setup/references/setup-commands.md
+++ b/skills/acp-builder-setup/references/setup-commands.md
@@ -30,7 +30,7 @@ scripts/configure-codex-virtuals.mjs virtuals
 This updates `~/.codex/config.toml` to use:
 
 ```toml
-model = "openai-gpt-55"
+model = "gpt-5.5"
 model_provider = "virtuals_proxy"
 
 [model_providers.virtuals_proxy]
@@ -38,6 +38,8 @@ name = "Virtuals via local Responses proxy"
 base_url = "http://127.0.0.1:8787/v1"
 wire_api = "responses"
 ```
+
+The Codex config uses the ChatGPT/Codex-supported `gpt-5.5` model id. The local proxy translates it to the Virtuals upstream model id `openai-gpt-55` when forwarding requests.
 
 Restore the previous Codex model/provider after the demo:
 

--- a/utilities/model-routing/claude-virtuals-router/README.md
+++ b/utilities/model-routing/claude-virtuals-router/README.md
@@ -33,6 +33,9 @@ After editing `~/.claude-code-router/config.json`, restart the router:
 ccr restart
 ```
 
+To choose which model each route uses (and discover available model ids), see
+[`docs/model-config.md`](../../../docs/model-config.md).
+
 Restore the previous router provider and route values after the demo:
 
 ```bash

--- a/utilities/model-routing/codex-virtuals-proxy/README.md
+++ b/utilities/model-routing/codex-virtuals-proxy/README.md
@@ -30,7 +30,7 @@ scripts/configure-codex-virtuals.mjs virtuals
 The script records the previous active Codex model/provider, then updates `~/.codex/config.toml` to use:
 
 ```toml
-model = "openai-gpt-55"
+model = "gpt-5.5"
 model_provider = "virtuals_proxy"
 
 [model_providers.virtuals_proxy]
@@ -38,6 +38,8 @@ name = "Virtuals via local Responses proxy"
 base_url = "http://127.0.0.1:8787/v1"
 wire_api = "responses"
 ```
+
+Codex validates the configured model id against Codex-supported model names when you sign in with a ChatGPT account. Keep the config model as `gpt-5.5`; this proxy maps it to Virtuals' upstream `openai-gpt-55` model before forwarding the request.
 
 Restore the previous Codex model/provider after the demo:
 

--- a/utilities/model-routing/codex-virtuals-proxy/server.mjs
+++ b/utilities/model-routing/codex-virtuals-proxy/server.mjs
@@ -15,6 +15,10 @@ const VIRTUALS_API_KEY = process.env.VIRTUALS_API_KEY;
 const LOCAL_API_KEY = process.env.VIRTUALS_PROXY_API_KEY;
 const DEBUG = process.env.VIRTUALS_PROXY_DEBUG === "1";
 const FORWARD_MAX_TOKENS = process.env.VIRTUALS_PROXY_FORWARD_MAX_TOKENS === "1";
+const MODEL_ALIASES = new Map([
+  ["gpt-5.5", "openai-gpt-55"],
+  ["gpt-5.4-mini", "openai-gpt-54-mini"],
+]);
 
 if (!VIRTUALS_API_KEY) {
   console.error("VIRTUALS_API_KEY is required.");
@@ -227,7 +231,7 @@ function responsesRequestToChat(request) {
   }
 
   const body = {
-    model: request.model,
+    model: upstreamModel(request.model),
     messages,
     stream: Boolean(request.stream),
   };
@@ -245,6 +249,10 @@ function responsesRequestToChat(request) {
   }
 
   return body;
+}
+
+function upstreamModel(model) {
+  return MODEL_ALIASES.get(model) || model;
 }
 
 function usageFromChat(chat) {
@@ -311,6 +319,9 @@ function chatResponseToResponses(chat, requestedModel) {
   const choice = chat.choices?.[0] || {};
   const message = choice.message || {};
   const output = chatMessageToOutput(message);
+  const responseModel = MODEL_ALIASES.has(requestedModel)
+    ? requestedModel
+    : chat.model || requestedModel;
 
   return {
     id: `resp_${randomUUID().replaceAll("-", "")}`,
@@ -322,7 +333,7 @@ function chatResponseToResponses(chat, requestedModel) {
     incomplete_details: null,
     instructions: null,
     max_output_tokens: null,
-    model: chat.model || requestedModel,
+    model: responseModel,
     output,
     output_text: output
       .flatMap((item) => item.content || [])
@@ -604,6 +615,7 @@ async function forwardResponses(req, res) {
     return;
   }
 
+  const requestedModel = responsesRequest.model;
   const chatRequest = responsesRequestToChat(responsesRequest);
   logDebug("responses request", JSON.stringify(responsesRequest, null, 2));
   logDebug("chat request", JSON.stringify(chatRequest, null, 2));
@@ -628,12 +640,12 @@ async function forwardResponses(req, res) {
   }
 
   if (chatRequest.stream) {
-    await handleStreamingResponse(res, upstream, chatRequest.model);
+    await handleStreamingResponse(res, upstream, requestedModel);
     return;
   }
 
   const chatResponse = await upstream.json();
-  sendJson(res, 200, chatResponseToResponses(chatResponse, chatRequest.model));
+  sendJson(res, 200, chatResponseToResponses(chatResponse, requestedModel));
 }
 
 async function forwardModels(req, res) {


### PR DESCRIPTION
## Summary

- Change the Codex Virtuals config helper to write Codex-supported model ids such as `gpt-5.5` instead of Virtuals-only ids such as `openai-gpt-55`.
- Add proxy-side aliases so Codex-facing model ids are translated to the correct Virtuals upstream model ids.
- Update the ACP builder setup skill and proxy docs to document the Codex-facing model id and upstream translation.
- Add `docs/model-config.md`: how to discover available model ids via the `/v1/models` endpoint and where the model parameter is set for Codex (`config.toml`) versus Claude Code (`claude-code-router` `config.json` — both `Providers[].models[]` and the `Router` map). Cross-linked from `README.md` and `docs/agent-setup.md`.
- Fix a restore-snapshot bug in both `configure-claude-virtuals.mjs` and `configure-codex-virtuals.mjs` that could silently discard config edits made between two activations.

## Root Cause

### Codex model id rejection
Codex validates the configured model id against ChatGPT/Codex-supported names when using a ChatGPT account. Writing `openai-gpt-55` directly into `~/.codex/config.toml` can fail even though Virtuals expects that upstream id.

### Stale restore snapshot
Both config helpers captured their restore state file only once — `writeStateIfMissing` returned early when the state file already existed. If the config was edited between two `virtuals` activations, `restore` reverted to the stale first snapshot and silently discarded the later edits (e.g. a custom `claude-code-router` transformer, or a manually switched Codex model). The helpers now re-capture the on-disk config on every activation, so `restore` always returns to the state immediately before the most recent activation. The pristine pre-Virtuals baseline remains preserved separately in `.before-virtuals.bak`.

## Validation

- `node --check scripts/configure-codex-virtuals.mjs`
- `node --check scripts/configure-claude-virtuals.mjs`
- `node --check utilities/model-routing/codex-virtuals-proxy/server.mjs`
- `git diff --check`
- temp config verification for default `gpt-5.5`
- temp config verification that legacy `--model openai-gpt-55` normalizes to `gpt-5.5`
- fresh Codex CLI smoke test through the patched proxy returned `virtuals-ok`
- live `/v1/chat/completions` probe through the Claude router returned a response with the `venice_parameters` block, confirming traffic reaches the Virtuals endpoint
- verified documented helper actions exist in source: `virtuals|restore|default|check` (claude), `virtuals|restore|default` (codex)
- end-to-end test that `--model` changes the served model: probe before (default route served `claude-opus-4-7-fast`) -> activate with `--model claude-opus-4-8` -> probe after (served `claude-opus-4-8`) -> `restore` (served `claude-opus-4-7-fast` again)
- restore-snapshot regression tests (both helpers): drift scenario restores to the edited config not the stale first snapshot; clean activate/restore is a byte-exact round trip; live Claude router config byte-identical before and after an activate/restore cycle