### PR TITLE
Fix restore-snapshot bug and add make lifecycle commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ node_modules/
 .env
 .env.*
 !.env.example
+
+# Background proxy state managed by the Makefile codex-* targets
+.proxy.pid
+.proxy.log

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,41 @@
+# Virtuals model-routing lifecycle. Run `make help` for the target list.
+#
+# These targets run in your shell, so `ccr restart` and the Codex proxy inherit
+# VIRTUALS_API_KEY from the same environment. Model selection uses the helper
+# defaults; for custom models, call the scripts directly (see
+# scripts/configure-claude-virtuals.mjs --help and
+# scripts/configure-codex-virtuals.mjs --help).
+
+SHELL := /bin/sh
+.DEFAULT_GOAL := help
+.PHONY: help claude-on claude-off claude-check codex-on codex-off codex-proxy
+
+help: # List available targets
+	@grep -E '^[a-zA-Z0-9_-]+:.*#' Makefile | while read -r l; do printf "\033[1;32m$$(echo $$l | cut -f 1 -d':')\033[00m:$$(echo $$l | cut -f 2- -d'#')\n"; done
+
+claude-on: # Activate Virtuals routing for Claude Code, validate it, then restart ccr
+	scripts/configure-claude-virtuals.mjs virtuals
+	scripts/configure-claude-virtuals.mjs check
+	ccr restart
+	@echo "Claude Code Router is routing through Virtuals. Start Claude with: ccr code"
+
+claude-off: # Restore the previous Claude Code Router config, then restart ccr
+	scripts/configure-claude-virtuals.mjs restore
+	ccr restart
+	@echo "Claude Code Router config restored."
+
+claude-check: # Validate the active Claude Code Router Virtuals config
+	scripts/configure-claude-virtuals.mjs check
+
+codex-on: # Start the proxy (background) and activate Virtuals routing for Codex
+	scripts/codex-proxy.sh start
+	scripts/configure-codex-virtuals.mjs virtuals
+	@echo "Codex is routing through the Virtuals proxy. Start a fresh Codex thread with: codex"
+
+codex-off: # Restore the previous Codex config and stop the proxy make started
+	scripts/configure-codex-virtuals.mjs restore
+	scripts/codex-proxy.sh stop
+	@echo "Codex config restored."
+
+codex-proxy: # Run the Codex proxy in the foreground (watch logs; Ctrl-C to stop)
+	cd utilities/model-routing/codex-virtuals-proxy && npm start

--- a/docs/agent-setup.md
+++ b/docs/agent-setup.md
@@ -85,6 +85,20 @@ scripts/configure-claude-virtuals.mjs check
 
 Keep shared utilities in `utilities/` so setup docs, skills, and examples evolve together.
 
+### Recovering Your Original Config
+
+`restore` reverts to the config from just before the most recent activation; if that snapshot is gone, it automatically falls back to a one-time baseline the first activation saved next to your config:
+
+- Claude Code: `~/.claude-code-router/config.json.before-virtuals.bak`
+- Codex: `~/.codex/config.toml.before-virtuals.bak`
+
+You normally never touch these. If you can't run `restore`, or you want the exact frozen original back, copy the baseline in by hand:
+
+```bash
+cp ~/.claude-code-router/config.json.before-virtuals.bak ~/.claude-code-router/config.json && ccr restart
+# Codex: cp ~/.codex/config.toml.before-virtuals.bak ~/.codex/config.toml, then start a fresh thread
+```
+
 ## Desktop Support Matrix
 
 | Surface | Skills from this repo | Virtuals routing utility | Status |

--- a/scripts/codex-proxy.sh
+++ b/scripts/codex-proxy.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Manage the local Codex Virtuals proxy as a background process.
+#
+#   scripts/codex-proxy.sh start    Start the proxy (if not already running),
+#                                   wait until it answers /health.
+#   scripts/codex-proxy.sh stop     Stop the proxy this script started.
+#   scripts/codex-proxy.sh status   Report whether the managed proxy is running.
+#
+# State lives next to the proxy: .proxy.pid and .proxy.log (both gitignored).
+# Host/port follow the proxy's own VIRTUALS_PROXY_HOST / VIRTUALS_PROXY_PORT.
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "$0")/.." && pwd)
+proxy_dir="$repo_root/utilities/model-routing/codex-virtuals-proxy"
+pid_file="$proxy_dir/.proxy.pid"
+log_file="$proxy_dir/.proxy.log"
+# Defaults mirror server.mjs (the source of truth); keep them in sync.
+host="${VIRTUALS_PROXY_HOST:-127.0.0.1}"
+port="${VIRTUALS_PROXY_PORT:-8787}"
+health="http://$host:$port/health"
+
+running() {
+  [ -f "$pid_file" ] && kill -0 "$(cat "$pid_file")" 2>/dev/null
+}
+
+start() {
+  if [ -z "${VIRTUALS_API_KEY:-}" ]; then
+    echo "VIRTUALS_API_KEY is not set in this shell. Export it before starting the proxy:" >&2
+    echo "  export VIRTUALS_API_KEY=..." >&2
+    return 1
+  fi
+
+  if running; then
+    echo "Proxy already running (pid $(cat "$pid_file"))."
+    return 0
+  fi
+
+  echo "Starting Codex proxy in the background (logs: $log_file)..."
+  ( cd "$proxy_dir" && exec node server.mjs >>"$log_file" 2>&1 ) &
+  echo $! >"$pid_file"
+
+  printf "Waiting for proxy at %s " "$health"
+  for _ in $(seq 1 30); do
+    if curl -fsS "$health" >/dev/null 2>&1; then
+      echo; echo "Proxy is up."
+      return 0
+    fi
+    printf "."
+    sleep 0.5
+  done
+
+  echo
+  echo "Proxy did not become reachable. Check $log_file."
+  rm -f "$pid_file"
+  return 1
+}
+
+stop() {
+  if [ ! -f "$pid_file" ]; then
+    echo "No make-managed proxy pidfile found; if you started the proxy yourself, stop it manually."
+    return 0
+  fi
+
+  local pid
+  pid=$(cat "$pid_file")
+  if kill -0 "$pid" 2>/dev/null; then
+    kill "$pid" && echo "Stopped Codex proxy (pid $pid)."
+  else
+    echo "Codex proxy (pid $pid) was not running."
+  fi
+  rm -f "$pid_file"
+}
+
+status() {
+  if running; then
+    echo "Proxy running (pid $(cat "$pid_file")) at $health."
+  else
+    echo "Proxy not running."
+  fi
+}
+
+case "${1:-}" in
+  start) start ;;
+  stop) stop ;;
+  status) status ;;
+  *)
+    echo "Usage: $0 {start|stop|status}" >&2
+    exit 2
+    ;;
+esac

--- a/scripts/codex-proxy.sh
+++ b/scripts/codex-proxy.sh
@@ -14,6 +14,46 @@ repo_root=$(cd "$(dirname "$0")/.." && pwd)
 proxy_dir="$repo_root/utilities/model-routing/codex-virtuals-proxy"
 pid_file="$proxy_dir/.proxy.pid"
 log_file="$proxy_dir/.proxy.log"
+
+trim() {
+  local value="$1"
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+  printf '%s' "$value"
+}
+
+load_dotenv() {
+  local env_file="$1"
+  local line key value
+
+  [ -f "$env_file" ] || return 0
+
+  while IFS= read -r line || [ -n "$line" ]; do
+    line=$(trim "$line")
+    [ -n "$line" ] || continue
+    case "$line" in
+      \#*) continue ;;
+      *=*) ;;
+      *) continue ;;
+    esac
+
+    key=$(trim "${line%%=*}")
+    value=$(trim "${line#*=}")
+    [[ "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
+
+    if { [[ "$value" == \"*\" ]] && [[ "$value" == *\" ]]; } ||
+      { [[ "$value" == \'* ]] && [[ "$value" == *\' ]]; }; then
+      value="${value:1:${#value}-2}"
+    fi
+
+    if [ -z "${!key+x}" ]; then
+      export "$key=$value"
+    fi
+  done <"$env_file"
+}
+
+load_dotenv "$proxy_dir/.env"
+
 # Defaults mirror server.mjs (the source of truth); keep them in sync.
 host="${VIRTUALS_PROXY_HOST:-127.0.0.1}"
 port="${VIRTUALS_PROXY_PORT:-8787}"

--- a/scripts/configure-claude-virtuals.mjs
+++ b/scripts/configure-claude-virtuals.mjs
@@ -169,8 +169,12 @@ function readConfig() {
 }
 
 function writeConfig(config) {
+  writeConfigText(`${JSON.stringify(config, null, 2)}\n`);
+}
+
+function writeConfigText(text) {
   mkdirSync(dirname(configPath), { recursive: true });
-  writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`, { mode: 0o600 });
+  writeFileSync(configPath, text, { mode: 0o600 });
 }
 
 function configureConfig() {
@@ -178,7 +182,6 @@ function configureConfig() {
   const originalConfig = readConfig();
   const next = clone(originalConfig);
 
-  captureRestoreState(originalText, originalConfig);
   next.Providers = upsertProvider(next.Providers, providerConfig());
   next.Router = {
     ...(next.Router && typeof next.Router === "object" ? next.Router : {}),
@@ -188,11 +191,18 @@ function configureConfig() {
     longContext: route(options.thinkModel),
   };
 
+  // Detect the no-op before capturing the restore snapshot. Capturing first
+  // would overwrite the existing snapshot with the current (already-Virtuals)
+  // config, destroying the path back to the user's pre-Virtuals config even
+  // though this run changes nothing. The existing restore point is kept.
   if (JSON.stringify(next) === JSON.stringify(originalConfig)) {
-    console.log(`Claude Code Router config already routes through ${options.provider}.`);
+    console.log(
+      `Claude Code Router config already routes through ${options.provider} — no changes made. Existing restore point kept.`,
+    );
     return;
   }
 
+  captureRestoreState(originalText, originalConfig);
   writeBackupIfMissing(originalText);
   writeConfig(next);
   console.log(`Updated ${configPath}`);
@@ -203,9 +213,18 @@ function configureConfig() {
 }
 
 function restoreConfig() {
+  // Precedence: the per-activation state snapshot is the most precise restore
+  // point, so prefer it. When it is missing (e.g. consumed by a prior restore,
+  // or destroyed by an older buggy build), fall back to the pristine
+  // `.before-virtuals.bak` baseline so there is still a path home. Only error
+  // toward `default` when neither exists.
   if (!existsSync(statePath)) {
+    if (existsSync(backupPath)) {
+      restoreFromBackup();
+      return;
+    }
     fail(
-      `No Virtuals state file found at ${statePath}. Use "scripts/configure-claude-virtuals.mjs default" to remove Virtuals routes.`,
+      `No Virtuals state file found at ${statePath} and no baseline at ${backupPath}. Use "scripts/configure-claude-virtuals.mjs default" to remove Virtuals routes.`,
     );
   }
 
@@ -227,6 +246,18 @@ function restoreConfig() {
 
   rmSync(statePath, { force: true });
   console.log(`Restored Claude Code Router config from ${statePath}`);
+  console.log(`Restart claude-code-router with: ccr restart`);
+}
+
+function restoreFromBackup() {
+  // The baseline is the verbatim pre-Virtuals config text. Write it straight
+  // back rather than reconstructing from a parsed snapshot. Keep the baseline
+  // file: it is the only frozen copy of the original config, and a later
+  // restore/recovery may still need it.
+  const baselineText = readFileSync(backupPath, "utf8");
+  writeConfigText(ensureTrailingNewline(baselineText));
+  console.log(`No restore snapshot found; restored Claude Code Router config from baseline ${backupPath}`);
+  console.log(`Kept baseline ${backupPath} for future recovery.`);
   console.log(`Restart claude-code-router with: ccr restart`);
 }
 
@@ -313,11 +344,11 @@ function route(model) {
 
 function captureRestoreState(originalText, originalConfig) {
   // Snapshot the config exactly as it is on disk right now, overwriting any
-  // previous snapshot. `restore` then always returns to the state immediately
-  // before the most recent activation. Capturing only once (the old behavior)
-  // left the snapshot stale whenever the config was edited between activations,
-  // so restore silently reverted those edits away. The genuine pre-Virtuals
-  // baseline is preserved separately in `.before-virtuals.bak`.
+  // previous snapshot, so `restore` returns to the state immediately before the
+  // most recent activation. The caller gates this on a real change (see the
+  // no-op check in configureConfig), so a repeat run never clobbers a good
+  // snapshot. The pre-Virtuals baseline is preserved separately in
+  // `.before-virtuals.bak`.
   const provider = findProvider(originalConfig.Providers, options.provider);
   const router = originalConfig.Router && typeof originalConfig.Router === "object" ? originalConfig.Router : {};
   const state = {

--- a/scripts/configure-codex-virtuals.mjs
+++ b/scripts/configure-codex-virtuals.mjs
@@ -162,17 +162,26 @@ function configureConfig() {
   const model = codexModelId(options.model);
 
   if (!options.addProviderOnly) {
-    captureRestoreState(original);
     next = setTopLevelKey(next, "model", model);
     next = setTopLevelKey(next, "model_provider", options.provider);
   }
 
   next = upsertProviderBlock(next, options.provider, providerBlock());
+
+  // Detect the no-op before capturing the restore snapshot. Capturing first
+  // would overwrite the existing snapshot with the current (already-Virtuals)
+  // config, destroying the path back to the user's pre-Virtuals config even
+  // though this run changes nothing. The existing restore point is kept.
   if (next === original) {
-    console.log(`Codex config already routes through ${options.provider}.`);
+    console.log(
+      `Codex config already routes through ${options.provider} — no changes made. Existing restore point kept.`,
+    );
     return;
   }
 
+  if (!options.addProviderOnly) {
+    captureRestoreState(original);
+  }
   writeBackupIfMissing(original);
   writeConfig(next);
   console.log(`Updated ${configPath}`);
@@ -193,9 +202,18 @@ function codexModelId(model) {
 }
 
 function restoreConfig() {
+  // Precedence: the per-activation state snapshot is the most precise restore
+  // point, so prefer it. When it is missing (e.g. consumed by a prior restore,
+  // or destroyed by an older buggy build), fall back to the pristine
+  // `.before-virtuals.bak` baseline so there is still a path home. Only error
+  // toward `default` when neither exists.
   if (!existsSync(statePath)) {
+    if (existsSync(backupPath)) {
+      restoreFromBackup();
+      return;
+    }
     fail(
-      `No Virtuals state file found at ${statePath}. Use "scripts/configure-codex-virtuals.mjs default" to switch back to built-in Codex routing.`,
+      `No Virtuals state file found at ${statePath} and no baseline at ${backupPath}. Use "scripts/configure-codex-virtuals.mjs default" to switch back to built-in Codex routing.`,
     );
   }
 
@@ -231,6 +249,17 @@ function restoreConfig() {
   console.log(`Restored Codex config from ${statePath}`);
 }
 
+function restoreFromBackup() {
+  // The baseline is the verbatim pre-Virtuals config text. Write it straight
+  // back rather than reconstructing from a parsed snapshot. Keep the baseline
+  // file: it is the only frozen copy of the original config, and a later
+  // restore/recovery may still need it.
+  const baselineText = readFileSync(backupPath, "utf8");
+  writeConfig(baselineText);
+  console.log(`No restore snapshot found; restored Codex config from baseline ${backupPath}`);
+  console.log(`Kept baseline ${backupPath} for future recovery.`);
+}
+
 function switchToDefaultCodex() {
   const original = readConfig();
   let next = original;
@@ -251,11 +280,11 @@ function switchToDefaultCodex() {
 
 function captureRestoreState(text) {
   // Snapshot the config exactly as it is on disk right now, overwriting any
-  // previous snapshot. `restore` then always returns to the state immediately
-  // before the most recent activation. Capturing only once (the old behavior)
-  // left the snapshot stale whenever the config was edited between activations,
-  // so restore silently reverted those edits away. The genuine pre-Virtuals
-  // baseline is preserved separately in `.before-virtuals.bak`.
+  // previous snapshot, so `restore` returns to the state immediately before the
+  // most recent activation. The caller gates this on a real change (see the
+  // no-op check in configureConfig), so a repeat run never clobbers a good
+  // snapshot. The pre-Virtuals baseline is preserved separately in
+  // `.before-virtuals.bak`.
   const provider = options.provider;
   const state = {
     createdAt: new Date().toISOString(),


### PR DESCRIPTION
## Summary
Some improvements to the acp-builder setup tooling and docs.

The first commit adds a fallback to the `restore` command so it can recover from the `.before-virtuals.bak` baseline when no restore snapshot exists.

The second commit adds a Makefile that captures the full lifecycle of setting up (and tearing down) Claude and Codex routing through the Virtuals server, so the steps aren't manual anymore. The `acp-builder-setup` is useful in helping one get started, but the teardown steps still needs to be done manually at the moment. 