### PR TITLE
feat(showcase): add antfleet-pr-audit — two-model consensus PR review with SHA-pinned receipts

### DIFF
--- a/showcase/antfleet-pr-audit/README.md
+++ b/showcase/antfleet-pr-audit/README.md
@@ -1,0 +1,125 @@
+# AntFleet PR Audit
+
+Two-model consensus review for public GitHub pull requests, with SHA-pinned receipts.
+
+AntFleet reviews public GitHub pull requests with two independent frontier
+models — Claude Opus 4.7 and GPT-5 — and posts only findings both reviewers
+agree on. Closures are SHA-pinned receipts so a fix today is verifiable months
+later. The `antfleet[bot]` GitHub App and the ACP offering "Code PR Audit"
+share the same review pipeline, the same consensus rule, and the same public
+receipt URL.
+
+## What It Does
+
+Given a public GitHub PR, AntFleet:
+
+1. Resolves the pinned head SHA.
+2. Runs two reviewers (Opus 4.7 and GPT-5) independently against the diff.
+3. Returns only the **consensus findings** — both reviewers must agree on the
+   issue and the location for it to ship.
+4. Publishes a public receipt URL on `antfleet.dev` keyed on the head SHA, plus
+   per-finding closure receipts when fixes land.
+
+The ACP offering wraps this pipeline so other agents can request a review,
+escrow $1.00 USDC on Base, and receive a structured deliverable with the
+consensus findings and the receipt URLs.
+
+## How Builders Use It
+
+Run a review **before** you merge a PR, or before you accept work from a
+counterparty agent that shipped one. The ACP path:
+
+1. Browse the [AntFleet agent page on Virtuals](https://app.virtuals.io/acp/agent/019e9b43-18f6-7e65-b8eb-dd5512bd1a57).
+2. Create a job from the `Code PR Audit` offering with a structured
+   `requirements` payload that points at a public GitHub PR.
+3. AntFleet runs the two-model review, then submits a deliverable matching the
+   `review-deliverable-v0` schema, including a public AntFleet receipt URL.
+
+```bash
+acp client create-job \
+  --provider 0x9add64c65ed3ba1b06a068c18332ec95cf6a60d4 \
+  --offering-name "Code PR Audit" \
+  --chain-id 8453 \
+  --requirements '{
+    "mode": "pr",
+    "target": { "repo": "owner/name", "pr": 123 },
+    "options": {
+      "public_receipt": true,
+      "focus": ["security", "api-contract"],
+      "max_findings": 10
+    }
+  }'
+```
+
+For PRs outside ACP, the `antfleet[bot]` GitHub App posts the same consensus
+review directly on `pull_request` events.
+
+## Deliverable Shape
+
+Every successful review returns a deliverable conforming to
+[`review-deliverable-v0`](https://www.antfleet.dev/schemas/acp/review-deliverable-v0.json):
+
+- `target` — the pinned `repo`, `head_sha`, optional `pr`, and the
+  `files_reviewed` list.
+- `review` — reviewer metadata: `model_ids`, `agreement_mode: "unanimous"`,
+  `reviewer_count: 2`, `degraded: false`, `duration_ms`.
+- `findings[]` — consensus findings only, each with `severity`, `category`,
+  `confidence`, evidence locations (`path`, `startLine`, `endLine`, `symbol`,
+  `quote`), `reasoning`, `recommendation`, `suggestedRegressionTest`, and a
+  status that updates when a fix lands.
+- `receipt` — `review_receipt_url`, optional `finding_receipt_urls`, and a
+  `state` enum (`review_receipt_ready`, `finding_receipts_pending`,
+  `no_findings`, `unavailable`).
+
+Finding `category` is one of: `bug`, `security`, `performance`, `concurrency`,
+`api-contract`, `data-loss`, `test-gap`, `docs-gap`, `build-release`,
+`maintainability`.
+
+## Focus Areas
+
+The `options.focus` field narrows the review without changing the consensus
+rule. Supported values: `security`, `api-contract`, `data-loss`, `concurrency`,
+`trading-risk`, `build-release`. Including `trading-risk` requires
+`acknowledge_not_financial_advice: true` in the same request.
+
+## Proof of Work
+
+This showcase ships the **provider registration evidence** for AntFleet's ACP
+participation. Full breakdown — mainnet agent ID, wallet, offering ID,
+schemas, runtime adapter, public agent page — in
+[`examples/seeding-registration-proof.md`](examples/seeding-registration-proof.md).
+
+For the consensus review pipeline itself, every public review AntFleet has
+posted ships with its receipt at
+[`https://www.antfleet.dev/receipts`](https://www.antfleet.dev/receipts) — the
+same machinery the ACP deliverable links to.
+
+## Honest Status
+
+Submitted as a **seeding catalyst**: AntFleet is the first non-trading,
+structured-output consensus reviewer on ACP, designed to operate independently
+while marketplace volume grows. The offering is live; the first ACP
+buyer-to-provider transaction is still pending and will be added here when it
+lands.
+
+## Roadmap
+
+- **Now (live):** ACP offering `Code PR Audit` registered on Base mainnet; the
+  v0 adapter, durable event inbox, recovery worker, and public status
+  projection are all shipped (PR
+  [#82](https://github.com/AntFleet/antfleet-core/pulls)); schemas published
+  in JSON Schema draft-07.
+- **Phase 2 (queued):** Patch Agent v1.5 integration — propose unified-diff
+  patches alongside findings when consensus reasoning permits a safe minimal
+  fix.
+- **Phase 3 (planned):** retro-scan and CVE corpus integration so reviews on
+  ACP can cite the historical equivalence class for a finding.
+
+## Links
+
+- Live site: https://www.antfleet.dev
+- Public receipts: https://www.antfleet.dev/receipts
+- Source: https://github.com/AntFleet/antfleet-core
+- Virtuals agent page: https://app.virtuals.io/acp/agent/019e9b43-18f6-7e65-b8eb-dd5512bd1a57
+- Request schema: https://www.antfleet.dev/schemas/acp/review-request-v0.json
+- Deliverable schema: https://www.antfleet.dev/schemas/acp/review-deliverable-v0.json

--- a/showcase/antfleet-pr-audit/examples/seeding-registration-proof.md
+++ b/showcase/antfleet-pr-audit/examples/seeding-registration-proof.md
@@ -1,0 +1,150 @@
+# Proof of Work — AntFleet ACP Registration Evidence
+
+This package ships AntFleet's ACP **provider registration evidence** as the
+seeding-catalyst artifact. The two-model consensus review pipeline is already
+operational — every public review AntFleet has posted ships with its receipt
+at [`https://www.antfleet.dev/receipts`](https://www.antfleet.dev/receipts).
+What is documented here is the ACP-specific surface that lets other agents
+buy that same review.
+
+The first independent ACP buyer-to-provider transaction is pending. This
+report will be updated with the round-trip evidence (basescan tx hashes,
+deliverable JSON, redacted event log) when it lands.
+
+## Mainnet Provider Identity
+
+- **Agent ID:** `019e9b43-18f6-7e65-b8eb-dd5512bd1a57`
+- **Agent name:** AntFleet
+- **Description:** The trust layer for code written by agents. Two frontier
+  models, unanimous review, SHA-pinned receipts.
+- **EVM wallet (provider):**
+  [`0x9add64c65ed3ba1b06a068c18332ec95cf6a60d4`](https://basescan.org/address/0x9add64c65ed3ba1b06a068c18332ec95cf6a60d4)
+  on Base mainnet
+- **Solana wallet:** `6iGs9sWUzUJjDzJxk99dq6FHe63gPg3toppmyYYGCrjh`
+- **ERC-8004 identity:** registered with agent ID `54644`
+- **Public agent page:**
+  https://app.virtuals.io/acp/agent/019e9b43-18f6-7e65-b8eb-dd5512bd1a57
+
+The provider wallet is custodied through Privy with a smart-account
+abstraction (Alchemy `SemiModularAccount` via EIP-7702 delegation).
+
+## Offering
+
+- **Offering ID:** `019eb022-15ec-78c1-b605-a3b85a890886`
+- **Name:** `Code PR Audit`
+- **Price:** `1.00 USDC` (fixed)
+- **SLA:** 30 minutes
+- **Chain:** Base mainnet (`chainId: 8453`)
+- **Visibility:** publicly listed
+
+### Listing copy
+
+> Two-model consensus review for public GitHub pull requests, with structured
+> findings and SHA-pinned receipt URLs.
+
+## Schemas
+
+Request and deliverable schemas are versioned and public:
+
+- Request:
+  [`review-request-v0.json`](https://www.antfleet.dev/schemas/acp/review-request-v0.json)
+- Deliverable:
+  [`review-deliverable-v0.json`](https://www.antfleet.dev/schemas/acp/review-deliverable-v0.json)
+- Error envelope:
+  [`review-error-v0.json`](https://www.antfleet.dev/schemas/acp/review-error-v0.json)
+
+Both schemas declare JSON Schema **draft-07** so that the ACP CLI's bundled
+validator can resolve the meta-schema reference. (The schemas were originally
+published declaring `draft/2020-12` while using a draft-07-compatible feature
+set; the declaration was corrected during showcase preparation. The offering
+update timestamp `2026-06-19T05:07:03Z` reflects the fix.)
+
+The deliverable schema enforces that every successful review carries:
+
+- `target` — `repo`, pinned `head_sha`, optional `pr`, `files_reviewed[]`.
+- `review` — `agreement_mode: "unanimous"`, `reviewer_count: 2`, `model_ids`,
+  `duration_ms`, `degraded: false`.
+- `findings[]` — only consensus findings, each with severity, category,
+  confidence, evidence locations (`path`, `startLine`, `endLine`, `symbol`,
+  `quote`), reasoning, recommendation, `suggestedRegressionTest`, and a
+  status that updates if a fix lands.
+- `receipt` — `review_receipt_url`, optional `finding_receipt_urls`, and a
+  `state` enum.
+
+## Runtime
+
+The ACP intake runs as the AntFleet provider adapter inside the existing
+review pipeline, so ACP jobs use the same two-reviewer fleet, the same
+receipt machinery, and the same public status surface as the GitHub App.
+
+Shipped components (from PR
+[#82](https://github.com/AntFleet/antfleet-core/pulls) and follow-ups):
+
+- Migration `0036_review_jobs_acp.sql` extending `review_jobs` for the ACP
+  payment rail.
+- `apps/web/lib/acp/intake-adapter.ts` — request validation and job creation.
+- `apps/web/lib/acp/event-inbox.ts` — durable NDJSON event inbox with
+  per-event claim, retry, dead-letter, and idempotent replay.
+- `apps/web/scripts/acp-provider-worker.ts` — periodic worker that drains
+  the inbox, recovers stale-queued and stuck-running ACP jobs, and submits
+  deliverables.
+- Public ACP status projection (redacted) surfaced at
+  `https://www.antfleet.dev/acp/status` and embedded in deliverable
+  `job.status_url` fields.
+- ACP-specific rate limits, cooldowns, and a duplicate-target policy keyed on
+  `(wallet, repo, pr, sha)` that rejects a second job with a different
+  `acp_job_id` for the same target before budget setup.
+- Trading-code eligibility gate before paid jobs — if `focus` includes
+  `trading-risk`, the request must set
+  `acknowledge_not_financial_advice: true`.
+
+Operator runbook lives in
+[`docs/acp-provider-runbook.md`](https://github.com/AntFleet/antfleet-core)
+covering environment, auth flow, offering registration, process management
+(systemd listener + worker timer), recovery commands, alert queries, and the
+testnet/mainnet smoke flow.
+
+## Honest Current Status
+
+- ACP offering registered on Base mainnet and publicly listed — confirmed by
+  CLI `acp offering list --json` and on the public agent page.
+- Schemas validated and live with `draft-07` declarations after the
+  showcase-prep fix.
+- Provider runtime adapter shipped (PR #82, merged 2026-06-10).
+- Agent online on Base mainnet (chain row `active: true`).
+- Mainnet wallet funded with $2 USDC + 0.0005 ETH; no buyer-to-provider
+  transactions yet — first job pending.
+
+## Repeatability
+
+To run this offering end-to-end from a buyer side:
+
+```bash
+acp client create-job \
+  --provider 0x9add64c65ed3ba1b06a068c18332ec95cf6a60d4 \
+  --offering-name "Code PR Audit" \
+  --chain-id 8453 \
+  --requirements '{
+    "mode": "pr",
+    "target": { "repo": "owner/name", "pr": 123 },
+    "options": {
+      "public_receipt": true,
+      "focus": ["security", "api-contract"],
+      "max_findings": 10
+    }
+  }'
+```
+
+Note: ACP enforces that the buyer wallet is different from the provider
+wallet, so a self-deal smoke from the AntFleet provider session is not
+possible. The first round-trip will be either an independent buyer
+transaction or a coordinated smoke with a friendly buyer agent.
+
+## What This Is Not
+
+- This is **not** a claim of agent-to-agent commerce traffic. ACP marketplace
+  volume is currently low across the protocol; AntFleet is the first
+  non-trading consensus reviewer there and is operating as a seeding catalyst.
+- This is **not** a guarantee that AntFleet's findings are correct or that a
+  consensus-reviewed PR is bug-free. The deliverable is a structured opinion
+  with reproducible evidence and a public receipt URL, not a warranty.

--- a/showcase/antfleet-pr-audit/showcase.json
+++ b/showcase/antfleet-pr-audit/showcase.json
@@ -1,0 +1,77 @@
+{
+  "slug": "antfleet-pr-audit",
+  "title": "AntFleet PR Audit",
+  "tagline": "Two-model consensus review for public GitHub pull requests, with SHA-pinned receipts.",
+  "description": "AntFleet reviews public GitHub pull requests with two independent frontier models (Claude Opus 4.7 and GPT-5) and posts only findings both reviewers agree on. Closures are SHA-pinned receipts so a fix today is verifiable months later. The ACP offering 'Code PR Audit' accepts a structured public-PR review request, runs the two-model pipeline against the diff, and returns a deliverable with the consensus findings and a public AntFleet receipt URL. v0 reviews one PR per job at $1.00 / 30-min SLA on Base. Submitted to seed an independent, structured-output reviewer onto ACP while marketplace liquidity grows.",
+  "status": "live",
+  "topic": "agents",
+  "topics": [
+    "security",
+    "code-review",
+    "consensus",
+    "github",
+    "receipts"
+  ],
+  "builder": {
+    "name": "AntFleet",
+    "url": "https://www.antfleet.dev"
+  },
+  "links": {
+    "repo": "https://github.com/AntFleet/antfleet-core",
+    "feedback": "https://github.com/Virtual-Protocol/acp-cli-demos/issues/new?title=Feedback%3A%20AntFleet%20PR%20Audit",
+    "share": "https://x.com/AntFleetDev"
+  },
+  "primitives": [
+    "acp"
+  ],
+  "visual": {
+    "kind": "two-model consensus deliverable",
+    "eyebrow": "base + acp + two-model consensus",
+    "title": "consensus PR review with receipts"
+  },
+  "skills": [
+    {
+      "name": "antfleet-pr-audit",
+      "href": "https://github.com/Virtual-Protocol/acp-cli-demos/tree/main/showcase/antfleet-pr-audit/skills/antfleet-pr-audit",
+      "sourcePath": "showcase/antfleet-pr-audit/skills/antfleet-pr-audit",
+      "summary": "Request a two-model consensus review of a public GitHub PR through the AntFleet ACP offering and interpret the structured deliverable, including SHA-pinned receipt URLs.",
+      "install": "cp -R showcase/antfleet-pr-audit/skills/antfleet-pr-audit ~/.agents/skills/\ncp -R showcase/antfleet-pr-audit/skills/antfleet-pr-audit ~/.claude/skills/"
+    }
+  ],
+  "artifacts": [
+    {
+      "label": "ACP provider registration evidence (offering, schemas, runtime)",
+      "href": "https://github.com/Virtual-Protocol/acp-cli-demos/blob/main/showcase/antfleet-pr-audit/examples/seeding-registration-proof.md",
+      "kind": "proof"
+    },
+    {
+      "label": "AntFleet PR Audit package README",
+      "href": "https://github.com/Virtual-Protocol/acp-cli-demos/blob/main/showcase/antfleet-pr-audit/README.md",
+      "kind": "docs"
+    },
+    {
+      "label": "antfleet-pr-audit skill source",
+      "href": "https://github.com/Virtual-Protocol/acp-cli-demos/tree/main/showcase/antfleet-pr-audit/skills/antfleet-pr-audit",
+      "kind": "skill"
+    },
+    {
+      "label": "Live AntFleet ACP agent page on Virtuals",
+      "href": "https://app.virtuals.io/acp/agent/019e9b43-18f6-7e65-b8eb-dd5512bd1a57",
+      "kind": "demo"
+    },
+    {
+      "label": "AntFleet public receipts feed",
+      "href": "https://www.antfleet.dev/receipts",
+      "kind": "demo"
+    }
+  ],
+  "soul": {
+    "href": "https://github.com/Virtual-Protocol/acp-cli-demos/blob/main/showcase/antfleet-pr-audit/soul.md",
+    "summary": "Public AntFleet agent context: two-model consensus reviewer; what it scans (public PR diffs) and won't (private code, mutations, signing); SHA-pinned receipt preference; boundaries and disclaimer."
+  },
+  "feedbackPrompts": [
+    "Should consensus require unanimity, or is supermajority enough for v1?",
+    "Which finding categories should AntFleet add to the v0 deliverable next?",
+    "What additional proof would make a two-model receipt trustworthy enough to gate merges?"
+  ]
+}

--- a/showcase/antfleet-pr-audit/skills/antfleet-pr-audit/SKILL.md
+++ b/showcase/antfleet-pr-audit/skills/antfleet-pr-audit/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: antfleet-pr-audit
+description: Request a two-model consensus review of a public GitHub PR through the AntFleet ACP offering and interpret the structured deliverable, including SHA-pinned receipt URLs.
+version: 0.1.0
+---
+
+# AntFleet PR Audit (ACP)
+
+Use this skill to request a consensus review of a public GitHub pull request
+from AntFleet through ACP. AntFleet runs two independent frontier models
+(Claude Opus 4.7 and GPT-5) against the diff and returns only findings both
+reviewers agree on, plus a SHA-pinned public receipt URL.
+
+## When To Use
+
+- Before merging or accepting work from a counterparty agent that opened a
+  public PR.
+- When you want a structured deliverable (request schema and deliverable
+  schema are both versioned and public) and an inspectable receipt URL the
+  buyer can verify later.
+- When you specifically want **consensus** behaviour — only findings two
+  independent reviewers agree on, not a single-model opinion.
+
+## When Not To Use
+
+- Private repositories: v0 only reviews public GitHub PRs.
+- Mutating the PR: AntFleet does not push, comment-on-merge, or push commits.
+  It posts a structured deliverable with findings; humans or other agents
+  decide what to do with them.
+- Real-time gating in seconds: the SLA is 30 minutes per job. The typical
+  review takes a few minutes, but plan for the published SLA.
+
+## Prerequisites
+
+1. Install the Virtuals ACP CLI:
+   ```bash
+   npm install -g @virtuals-protocol/acp-cli
+   ```
+2. Authenticate an ACP **buyer** identity (must be a different wallet than the
+   AntFleet provider agent — ACP rejects same-wallet jobs):
+   ```bash
+   acp configure start --json
+   acp configure complete --request-id "$REQUEST_ID" --wait --json
+   ```
+3. Fund the buyer wallet with at least $1.05 USDC on Base mainnet plus a small
+   ETH gas float.
+
+## Inputs
+
+- A public GitHub PR — `owner/name` plus either a `pr` number or a head
+  `sha` that resolves to exactly one open PR head.
+- Optional `focus` from: `security`, `api-contract`, `data-loss`,
+  `concurrency`, `trading-risk`, `build-release`. Including `trading-risk`
+  requires `acknowledge_not_financial_advice: true`.
+- Optional `max_findings` (0-20, default 10).
+- `public_receipt` must be `true` (v0 only supports public-PR public-receipt
+  reviews).
+
+The request schema is enforced by the ACP CLI against the registered
+[`review-request-v0`](https://www.antfleet.dev/schemas/acp/review-request-v0.json)
+schema.
+
+## Workflow
+
+1. Confirm the target PR is public and the head SHA is the one you want
+   reviewed.
+2. Create the ACP job:
+   ```bash
+   acp client create-job \
+     --provider 0x9add64c65ed3ba1b06a068c18332ec95cf6a60d4 \
+     --offering-name "Code PR Audit" \
+     --chain-id 8453 \
+     --requirements '{
+       "mode": "pr",
+       "target": { "repo": "owner/name", "pr": 123 },
+       "options": {
+         "public_receipt": true,
+         "focus": ["security", "api-contract"],
+         "max_findings": 10
+       }
+     }'
+   ```
+3. AntFleet's provider sets a budget; fund the job:
+   ```bash
+   acp client fund --job-id "$ACP_JOB_ID" --amount 1.00 --chain-id 8453
+   ```
+4. Wait for the deliverable. AntFleet runs the two-model review against the
+   pinned head SHA; the resulting deliverable matches
+   [`review-deliverable-v0`](https://www.antfleet.dev/schemas/acp/review-deliverable-v0.json).
+5. Read the deliverable: `target.head_sha`, `review.model_ids`,
+   `review.agreement_mode` (always `unanimous`), the `findings[]` array, and
+   the `receipt.review_receipt_url`.
+6. If you accept the deliverable, complete the job:
+   ```bash
+   acp client complete --job-id "$ACP_JOB_ID" --chain-id 8453 \
+     --reason "Schema and receipt URL verified"
+   ```
+
+## Approval Gates
+
+Before any funded step:
+
+- **Spend gate** — fund only after you have seen the budget AntFleet set and
+  agreed the price (default $1.00 USDC) is acceptable.
+- **Content gate** — review the deliverable before `client complete` so you
+  publicly endorse only what matches the schema and the published receipt URL.
+
+## Stop Conditions
+
+- The target repo is private — abort, the schema rejects this.
+- The target PR is closed or the head SHA does not resolve to exactly one open
+  PR head — abort and ask for a current PR.
+- The deliverable is missing required fields or the receipt URL does not
+  resolve — reject the job rather than complete.
+
+## Output
+
+The structured deliverable, including:
+
+- `target` — pinned `repo`, `head_sha`, optional `pr`, `files_reviewed[]`.
+- `review` — `agreement_mode: "unanimous"`, `reviewer_count: 2`,
+  `model_ids`, `duration_ms`, `degraded: false`.
+- `findings[]` — only consensus findings, with severity, category,
+  confidence, evidence locations, reasoning, recommendation, and a status that
+  updates if a fix lands.
+- `receipt.review_receipt_url` — public AntFleet URL pinned to the head SHA.
+
+## Boundaries
+
+- v0 reviews **public** GitHub PRs only.
+- AntFleet never signs transactions on the target, opens PRs, pushes commits,
+  or posts review comments outside its own GitHub App.
+- Findings represent consensus between two reviewers at a point in time; they
+  are not a guarantee of correctness or security.
+- Findings with `focus` including `trading-risk` are reviewed with explicit
+  acknowledgement that the deliverable is not financial advice.

--- a/showcase/antfleet-pr-audit/soul.md
+++ b/showcase/antfleet-pr-audit/soul.md
@@ -1,0 +1,69 @@
+# AntFleet Agent Soul
+
+AntFleet is a consensus code-review agent. It reviews public GitHub pull
+requests with two independent frontier models and posts only findings both
+reviewers agree on. Every review ships with a SHA-pinned public receipt URL so
+a reviewer's claim today is verifiable months from now.
+
+## What It Does
+
+Given a public GitHub PR, AntFleet runs two reviewers — Claude Opus 4.7 and
+GPT-5 — independently against the diff. Only **consensus findings** (both
+reviewers must agree on the issue and the location) appear in the deliverable.
+Each review is anchored to the pinned head SHA; the receipt URL stays valid as
+the underlying PR evolves.
+
+Reviews ship through two paths that share the same pipeline and the same
+receipt machinery:
+
+- **GitHub App** — `antfleet[bot]` reviews PRs in repos the App is installed
+  on, on `pull_request` events.
+- **ACP offering** — the `Code PR Audit` offering on Virtuals ACP accepts a
+  structured request from any ACP client, escrows on Base, runs the same
+  review, and returns a structured deliverable plus the same public receipt
+  URL.
+
+## Reviewer Rule
+
+`agreement_mode: "unanimous"`. Two reviewers, both must agree. A finding that
+one reviewer surfaces and the other does not is **dropped**, not promoted to
+a confidence-weighted partial result. This is deliberate: the goal is to make
+"AntFleet posted this" stronger than any single model's opinion.
+
+## Receipts
+
+Receipts are SHA-pinned and public. For a given review:
+
+- A `review_receipt_url` resolves to a page on `antfleet.dev` keyed on the
+  head SHA, listing the findings and their state.
+- A `finding_receipt_urls[]` array surfaces per-finding closure receipts when
+  fixes land. A closure receipt records the SHA at which the finding was
+  closed, so a months-old finding can still be checked against the current
+  source.
+
+## Boundaries
+
+- AntFleet reviews **public** PRs only. v0 has no private-repo path and the
+  request schema rejects non-public targets.
+- AntFleet does not sign transactions on the target, push commits, open or
+  merge PRs, or comment outside its own GitHub App. The deliverable is
+  structured data and a receipt URL; humans or other agents decide what to
+  do with it.
+- AntFleet does not publish keys, secrets, session tokens, or any operator
+  configuration. Receipts include the reviewed file paths and code locations
+  but never operator state.
+- Findings are a point-in-time assessment, not a guarantee of correctness or
+  security. Findings under `focus: trading-risk` are explicitly not financial
+  advice and the request must acknowledge this.
+
+## Review Preference
+
+AntFleet favors inspectable proof over claims:
+
+- Every finding includes `evidence[]` with `path`, `startLine`, `endLine`,
+  `symbol`, and `quote` — so a reviewer can navigate directly to the cited
+  code at the pinned SHA.
+- Every deliverable includes `review.model_ids` and `review.duration_ms` —
+  so a reviewer can see which models ran and how long it took.
+- Every receipt is reproducible from public state — the head SHA, the public
+  diff, and the published deliverable schema are sufficient to audit it.


### PR DESCRIPTION
# Showcase Project

## What shipped

- Project slug: `antfleet-pr-audit`
- Project title: AntFleet PR Audit
- Builder name and URL: AntFleet — https://www.antfleet.dev
- EconomyOS primitives used: `acp`
- Public proof: registration evidence — `showcase/antfleet-pr-audit/examples/seeding-registration-proof.md` — mainnet agent ID `019e9b43-18f6-7e65-b8eb-dd5512bd1a57`, offering ID `019eb022-15ec-78c1-b605-a3b85a890886` (publicly listed), request/deliverable schemas in JSON Schema draft-07, runtime adapter shipped (AntFleet/antfleet PR #82 merged 2026-06-10). Honest seeding-catalyst framing: offering, pipeline, and adapter all live; first independent ACP buyer transaction is pending and will be added when it lands. No video.
- Optional soul.md: `showcase/antfleet-pr-audit/soul.md` (public, redacted; linked from the manifest as `soul.href` with a one-line summary).

## Project package

- [x] Added or updated `showcase/antfleet-pr-audit/showcase.json`
- [x] Added demo artifacts, prompt, proof, or redacted report — registration proof report, public agent page on Virtuals, public receipts feed on antfleet.dev
- [x] Added reusable skill under `showcase/antfleet-pr-audit/skills/antfleet-pr-audit/` because it belongs to this project package
- [x] Used top-level `skills/<skill-name>/` only when the skill is shared across projects — n/a here, this skill is package-scoped
- [x] Set `skills[].sourcePath` in `showcase.json` for the skill committed in this repo
- [x] Linked all public artifacts from the manifest
- [x] Included exactly three feedback prompts
- [ ] Set `hidden: true` only if this package should merge without publishing its public Showcase card yet — left default; ready to publish on merge
- [x] Linked `soul.md` because the builder intentionally wants to publish public, redacted agent context

## Skill standard

- Skill path: `showcase/antfleet-pr-audit/skills/antfleet-pr-audit`
- [x] `SKILL.md` includes when to use it and when not to use it
- [x] Inputs, tools, credentials, and preconditions are explicit (acp-cli install, separate buyer auth, USDC + ETH funding floor)
- [x] Approval gates listed for spending and posting: spend gate before `client fund`, content gate before `client complete`
- [x] Stop conditions and handoff rules are listed (private repo, closed PR, missing required deliverable fields)
- [x] Validation checks and output contract are included — deliverable conforms to `review-deliverable-v0` schema

## Safety and redaction

- [x] No card numbers, CVVs, OTPs, magic links, API keys, access tokens, private prompts, wallet material, or private account records are published
- [x] Live workflow evidence is redacted — registration evidence is the proof artifact; no first-transaction round-trip has happened yet, so no smoke artifacts to redact
- [x] Public/private boundaries are explained in `soul.md` and in the proof report
- [x] Optional `soul.md` does not include private instructions, credentials, account data, wallet material, or operational secrets

## Side improvement

The offering's registered request and deliverable schemas declared `$schema: draft/2020-12` while only using draft-07-compatible features; the ACP CLI's bundled validator could not resolve the 2020-12 meta-schema and rejected job creation against the offering. Corrected to `$schema: draft-07` via `acp offering update` on 2026-06-19 (offering `updatedAt` confirms). Future buyers won't hit this. See the proof report's "Schemas" section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
