### PR TITLE
feat: default claude-code-router to claude-sonnet-4-6, add glm-5-2 to allowlist

### DIFF
--- a/scripts/configure-claude-virtuals.mjs
+++ b/scripts/configure-claude-virtuals.mjs
@@ -10,10 +10,12 @@ const DEFAULT_MODELS = [
   "openai-gpt-55",
   "openai-gpt-55-pro",
   "openai-gpt-54-mini",
+  "claude-sonnet-4-6",
   "claude-opus-4-7-fast",
   "claude-opus-4-8",
+  "glm-5-2",
 ];
-const DEFAULT_MODEL = "claude-opus-4-7-fast";
+const DEFAULT_MODEL = "claude-sonnet-4-6";
 const DEFAULT_THINK_MODEL = "claude-opus-4-8";
 const ROUTER_KEYS = ["default", "background", "think", "longContext"];
 


### PR DESCRIPTION
Updates the default model configuration for Claude Code Router to better balance cost and capability.

**Changes:**
- `DEFAULT_MODEL`: `claude-opus-4-7-fast` → `claude-sonnet-4-6` (used for `default` and `background` routes)
- `DEFAULT_THINK_MODEL`: unchanged (`claude-opus-4-8`, used for `think` and `longContext` routes)
- Added `claude-sonnet-4-6` and `glm-5-2` to `DEFAULT_MODELS` allowlist

**Rationale:**
Sonnet 4.6 offers a better default for interactive and background work — 1M context window, meaningfully cheaper than Opus, and well-suited for everyday coding tasks. Opus is preserved for the `think` and `longContext` routes where stronger reasoning is worth the cost. GLM-5-2 is added to the allowlist as an alternative option for users who want to experiment with it.