### PR TITLE
docs: reframe ACP builder setup around the make routing lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,12 @@ Routing your agent through Virtuals lets it use free Virtuals credits instead of
 your own account, and is fully reversible. The simple path is the `make`
 lifecycle — run `make help` for the full list:
 
-```bash
-make claude-on   # use it: ccr code   # make claude-off  → back to your account
-make codex-on    # use it: codex      # make codex-off   → back to your account
 ```
+Claude Code:  make claude-on  →  ccr code  →  make claude-off
+Codex:        make codex-on   →  codex     →  make codex-off
+```
+
+`*-on` switches you onto Virtuals credits; `*-off` returns you to your own account.
 
 See [`docs/agent-setup.md`](docs/agent-setup.md) for the on → use → off → recover
 walkthrough with diagrams. The `Codex Virtuals Proxy` and `Claude Virtuals

--- a/README.md
+++ b/README.md
@@ -57,6 +57,21 @@ Packaged skills: [`packages/`](packages)
 
 Utility layout guidance: [`utilities/README.md`](utilities/README.md)
 
+### Virtuals Routing Lifecycle (optional)
+
+Routing your agent through Virtuals lets it use free Virtuals credits instead of
+your own account, and is fully reversible. The simple path is the `make`
+lifecycle — run `make help` for the full list:
+
+```bash
+make claude-on   # use it: ccr code   # make claude-off  → back to your account
+make codex-on    # use it: codex      # make codex-off   → back to your account
+```
+
+See [`docs/agent-setup.md`](docs/agent-setup.md) for the on → use → off → recover
+walkthrough with diagrams. The `Codex Virtuals Proxy` and `Claude Virtuals
+Router` sections below cover the underlying scripts.
+
 ### Codex Virtuals Proxy
 
 Path: [`utilities/model-routing/codex-virtuals-proxy`](utilities/model-routing/codex-virtuals-proxy)

--- a/docs/agent-setup.md
+++ b/docs/agent-setup.md
@@ -49,6 +49,13 @@ commands in order — follow [`skills/acp-builder-setup/references/setup-command
 This section explains how routing works and is the reference for recovery and
 advanced use.
 
+**What `VIRTUALS_API_KEY` is for.** It authenticates you to Virtuals' compute
+endpoint (`https://compute.virtuals.io/v1`) — the service that runs the models and
+draws down your credits. The router (Claude Code) and the local proxy (Codex)
+don't validate it themselves; they just carry it on each upstream request. It is
+read from your shell, not baked into any config file. Get one from
+[app.virtuals.io](https://app.virtuals.io/).
+
 To discover available model IDs and choose which model each agent uses, see [`docs/model-config.md`](model-config.md).
 
 The simple path is the `make` lifecycle (run `make help` for all targets). It

--- a/docs/agent-setup.md
+++ b/docs/agent-setup.md
@@ -44,6 +44,11 @@ your own account**. It is fully reversible.
 > account. The lifecycle below is just: turn **on → use → off**, with a **recover**
 > path if anything goes wrong.
 
+**New here?** For the step-by-step first-time runbook — prerequisites, the
+commands in order — follow [`skills/acp-builder-setup/references/setup-commands.md`](../skills/acp-builder-setup/references/setup-commands.md).
+This section explains how routing works and is the reference for recovery and
+advanced use.
+
 To discover available model IDs and choose which model each agent uses, see [`docs/model-config.md`](model-config.md).
 
 The simple path is the `make` lifecycle (run `make help` for all targets). It

--- a/docs/agent-setup.md
+++ b/docs/agent-setup.md
@@ -32,60 +32,90 @@ For one-off local installs, copying is fine:
 scripts/install-local-skills.sh --mode copy --target both
 ```
 
-## Model Routing Utilities
+## Model Routing Utilities (optional — free Virtuals credits)
+
+Routing your agent through Virtuals is **optional**. It lets you use
+Virtuals-hosted models so inference is billed to **Virtuals credits instead of
+your own account**. It is fully reversible.
+
+> **Read this first.** When routing is **ON**, your Claude Code / Codex spends
+> **Virtuals credits**, not your Anthropic/OpenAI account — even though it still
+> looks like "your" Claude or Codex. Turning it **OFF** puts you back on your own
+> account. The lifecycle below is just: turn **on → use → off**, with a **recover**
+> path if anything goes wrong.
 
 To discover available model IDs and choose which model each agent uses, see [`docs/model-config.md`](model-config.md).
 
-Codex and Claude Code need different local routing surfaces when using Virtuals-hosted models:
+The simple path is the `make` lifecycle (run `make help` for all targets). It
+wraps the scripts below and handles validation, the proxy, and `ccr` restarts for
+you. Set `VIRTUALS_API_KEY` in your shell first.
 
-- Codex custom providers call `/v1/responses`; use [`utilities/model-routing/codex-virtuals-proxy`](../utilities/model-routing/codex-virtuals-proxy).
-- Claude Code calls Anthropic-compatible `/v1/messages`; use [`utilities/model-routing/claude-virtuals-router`](../utilities/model-routing/claude-virtuals-router) with `claude-code-router`.
+### Three moving parts
 
-For Codex, use the config helper instead of hand-editing `~/.codex/config.toml`:
+Routing looks like three tools doing one thing. They are distinct:
 
-```bash
-scripts/configure-codex-virtuals.mjs virtuals
+| Part | What it is | Tool |
+| --- | --- | --- |
+| **Config switcher** | Edits your global config + saves a restore point | `make *-on/off` → `scripts/configure-*-virtuals.mjs` |
+| **Proxy** (Codex only) | Translates Codex `/v1/responses` → Virtuals Chat Completions | `make codex-proxy` / `scripts/codex-proxy.sh` |
+| **Agent runtime** | What actually sends your traffic | `ccr code` / `codex` |
+
+Codex needs the proxy because its custom providers call `/v1/responses`; Claude
+Code calls Anthropic-compatible `/v1/messages` and is routed by `claude-code-router`.
+
+### Claude Code lifecycle
+
+```mermaid
+flowchart LR
+    A["Your account<br/>(Anthropic)"] -->|make claude-on| B["configure-claude-virtuals<br/>writes config + restore point,<br/>ccr restart"]
+    B --> C["ccr code<br/>▶ traffic uses VIRTUALS CREDITS"]
+    C -->|make claude-off| D["restore previous config,<br/>ccr restart"]
+    D --> A
 ```
 
-It records the previous active Codex model/provider and can restore it after the demo:
-
 ```bash
-scripts/configure-codex-virtuals.mjs restore
+make claude-on      # activate Virtuals routing, validate, restart ccr
+ccr code            # use Claude Code on Virtuals credits
+make claude-check   # (read-only) validate the active router config
+make claude-off     # back to your own account
 ```
 
-If no restore state exists, switch back to built-in Codex routing:
+### Codex lifecycle
 
-```bash
-scripts/configure-codex-virtuals.mjs default
+```mermaid
+flowchart LR
+    A["Your account<br/>(OpenAI)"] -->|make codex-on| B["codex-proxy.sh starts local<br/>proxy :8787 + configure-codex-virtuals<br/>points config at it"]
+    B --> C["codex (fresh thread)<br/>Responses ▶ proxy ▶ VIRTUALS CREDITS"]
+    C -->|make codex-off| D["restore previous config,<br/>stop the proxy"]
+    D --> A
 ```
 
-For Claude Code, use the router config helper instead of hand-editing `~/.claude-code-router/config.json`:
-
 ```bash
-scripts/configure-claude-virtuals.mjs virtuals
+make codex-on       # start the local proxy (background) + point Codex at it
+codex               # start a FRESH thread so it picks up the new provider
+make codex-off      # back to your own account (also stops the proxy)
+make codex-proxy    # alt: run the proxy in the foreground to watch logs
 ```
 
-It records the previous `claude-code-router` provider and route values and can restore them after the demo:
+### Advanced: call the scripts directly
+
+The `make` targets wrap `scripts/configure-codex-virtuals.mjs` and
+`scripts/configure-claude-virtuals.mjs`. Use the scripts directly for a
+non-default model or manual recovery. Both support
+`virtuals | restore | default | check`:
 
 ```bash
-scripts/configure-claude-virtuals.mjs restore
-```
+scripts/configure-codex-virtuals.mjs restore               # previous Codex model/provider
+scripts/configure-codex-virtuals.mjs default               # built-in Codex routing (no restore state)
 
-If no restore state exists, remove the Virtuals provider and Virtuals routes:
-
-```bash
-scripts/configure-claude-virtuals.mjs default
-```
-
-Validate the active router config before starting Claude Code:
-
-```bash
-scripts/configure-claude-virtuals.mjs check
+scripts/configure-claude-virtuals.mjs restore && ccr restart   # previous provider/routes
+scripts/configure-claude-virtuals.mjs default && ccr restart   # remove Virtuals routes
+scripts/configure-claude-virtuals.mjs check                    # validate active config
 ```
 
 Keep shared utilities in `utilities/` so setup docs, skills, and examples evolve together.
 
-### Recovering Your Original Config
+### Recover: getting your original config back
 
 `restore` reverts to the config from just before the most recent activation; if that snapshot is gone, it automatically falls back to a one-time baseline the first activation saved next to your config:
 

--- a/skills/acp-builder-setup/SKILL.md
+++ b/skills/acp-builder-setup/SKILL.md
@@ -5,25 +5,38 @@ description: Set up ACP builder workflows for Codex, Claude Code, and Claude Des
 
 # ACP Builder Setup
 
-Use this skill when helping a builder prepare Codex or Claude for ACP demos, skills, and Virtuals-hosted model routing.
+Use this skill to help a builder get ready to run ACP demos and skills. There are
+two separate jobs, and they have very different stakes:
+
+1. **Install the ACP skill** — required. Just copies files into the agent
+   runtime. Safe.
+2. **Route through Virtuals for free credits** — optional. Edits the user's
+   global agent config. Fully reversible, but get the user's OK first.
+
+Do flow 1 for everyone. Only do flow 2 if the user wants to use Virtuals' free
+inference credits instead of their own Anthropic/OpenAI account.
 
 ## Surface Selection
 
-First identify the target surface:
+First identify the target surface — it decides which commands apply:
 
 - **Codex CLI or Codex Desktop local thread**: can use local files, `acp-cli`, `~/.agents/skills`, and `~/.codex/config.toml`.
 - **Claude Code terminal**: can use local files, `acp-cli`, `~/.claude/skills`, and `claude-code-router`.
-- **Claude Desktop app**: uses uploaded Skills from Claude settings. It does not automatically read `~/.claude/skills` or `claude-code-router`.
+- **Claude Desktop app**: uses uploaded Skills from Claude settings. It does **not** read `~/.claude/skills` or `claude-code-router`, so flow 2 (routing) does not apply — use the ZIP upload path instead.
 
 If the target surface is unclear, ask which tool they are setting up before changing files.
 
-## Skill Installation
+## 1. Install the ACP skill (required)
 
-Use this repo as the source of truth. Prefer symlinks for local development and copies for one-off installs.
+This installs the demo skills into the runtime. It only copies or links files —
+no global config is touched.
 
-For exact commands, read `references/setup-commands.md`.
+Use this repo as the source of truth. Prefer symlinks for local development and
+copies for one-off installs. For exact commands, read `references/setup-commands.md`.
 
-Do not assume repo-scoped `.agents/skills` or `.claude/skills` folders exist. This repo keeps canonical skills directly under `skills/`, then installs or links them into each local runtime.
+Do not assume repo-scoped `.agents/skills` or `.claude/skills` folders exist.
+This repo keeps canonical skills directly under `skills/`, then installs or links
+them into each local runtime.
 
 Install these local-execution skills for Codex CLI/Desktop and Claude Code:
 
@@ -35,36 +48,40 @@ Install these Claude Desktop upload packages:
 - `packages/claude-desktop/acp-builder-setup.zip`
 - `packages/claude-desktop/acp-paid-subscription-checkout.zip`
 
-In Claude Desktop, the combined checkout skill must use handoff or evidence-review mode unless the user has a separate local-tool bridge. Live checkout execution assumes local command execution, browser automation, and live payment controls.
+In Claude Desktop, the combined checkout skill must use handoff or evidence-review
+mode unless the user has a separate local-tool bridge. Live checkout execution
+assumes local command execution, browser automation, and live payment controls.
 
-## Model Routing
+## 2. (Optional) Route through Virtuals for free credits
 
-Codex and Claude Code need different local routing utilities:
+Optional perk: point the agent at Virtuals-hosted models so inference is billed to
+**Virtuals credits instead of the user's own account**. Skip this entirely on
+Claude Desktop — it can't use `ccr` or the proxy.
 
-- Codex: run `utilities/model-routing/codex-virtuals-proxy`, then use `scripts/configure-codex-virtuals.mjs virtuals` from the repo root to point `~/.codex/config.toml` at `http://127.0.0.1:8787/v1`. Codex config must use a Codex-supported model id such as `gpt-5.5`; the local proxy maps that to the upstream Virtuals model id.
-- Claude Code: use `scripts/configure-claude-virtuals.mjs virtuals` from the repo root to point `~/.claude-code-router/config.json` at Virtuals through `claude-code-router`.
-- Claude Desktop: do not claim the local router works. Desktop does not inherit `ccr code` or Codex proxy settings.
+The exact commands and the lifecycle diagrams live elsewhere — do not restate them
+here:
 
-### Codex Config Switching
+- [`references/setup-commands.md`](references/setup-commands.md) — copy-paste commands (bundled with this skill).
+- [`docs/agent-setup.md`](../../docs/agent-setup.md) — human walkthrough with diagrams, the three moving parts (config switcher / proxy / agent runtime), and recovery.
 
-Use the helper instead of manually editing `~/.codex/config.toml`:
+Your job is to run that lifecycle **safely**. Three behaviors:
 
-- Switch Codex to the Virtuals proxy: `scripts/configure-codex-virtuals.mjs virtuals`
-- Switch back to the exact previous Codex model/provider: `scripts/configure-codex-virtuals.mjs restore`
-- If no restore state exists, switch back to built-in Codex routing: `scripts/configure-codex-virtuals.mjs default`
+**Explain the mental model first.** Routing ON → the agent spends Virtuals
+credits, not the user's Anthropic/OpenAI account (even though it still looks like
+"their" Claude/Codex). Routing OFF → back on their own account. Fully reversible.
 
-After switching config, start a fresh Codex CLI or Codex Desktop local thread so it picks up the updated provider. Do not stop a proxy that an active Codex thread is still using.
+**Confirm before mutating config.** The lifecycle is `make claude-on` / `make
+claude-off` (Claude Code) and `make codex-on` / `make codex-off` (Codex), run from
+the repo root with `VIRTUALS_API_KEY` set. These edit the user's global config
+(`~/.claude-code-router/config.json`, `~/.codex/config.toml`), so treat them like
+provisioning: recommend the exact command for the detected surface, say it's
+reversible, and wait for explicit authorization. `make claude-check` is read-only
+— run it freely.
 
-### Claude Code Config Switching
-
-Use the helper instead of manually editing `~/.claude-code-router/config.json`:
-
-- Switch Claude Code Router to Virtuals: `scripts/configure-claude-virtuals.mjs virtuals`
-- Check the active router config: `scripts/configure-claude-virtuals.mjs check`
-- Switch back to the previous Claude Code Router provider/routes: `scripts/configure-claude-virtuals.mjs restore`
-- If no restore state exists, remove Virtuals provider/routes: `scripts/configure-claude-virtuals.mjs default`
-
-After switching config, restart the router with `ccr restart` before launching `ccr code`. The Virtuals provider must include the `cleancache` transformer because Claude Code adds Anthropic prompt-cache metadata that Virtuals Chat Completions can reject.
+**Always offer teardown.** Whenever routing is on (or you just turned it on), tell
+the user the one command back to their own account: `make claude-off` or `make
+codex-off`. If teardown fails, point them at the "Recover" section of
+[`docs/agent-setup.md`](../../docs/agent-setup.md).
 
 ## Environment Checks
 
@@ -81,5 +98,5 @@ End with:
 
 - Which surface was configured.
 - Which skills were installed or packaged.
-- Which router, if any, was configured.
+- Whether Virtuals routing was left **ON** (using Virtuals credits) or **OFF** (on the user's own account), and the command to turn it off (`make claude-off` / `make codex-off`).
 - Any manual action still needed, especially Claude Desktop ZIP upload or skill toggles.

--- a/skills/acp-builder-setup/SKILL.md
+++ b/skills/acp-builder-setup/SKILL.md
@@ -58,8 +58,7 @@ Optional perk: point the agent at Virtuals-hosted models so inference is billed 
 **Virtuals credits instead of the user's own account**. Skip this entirely on
 Claude Desktop — it can't use `ccr` or the proxy.
 
-The exact commands and the lifecycle diagrams live elsewhere — do not restate them
-here:
+The exact commands and the lifecycle diagrams live here:
 
 - [`references/setup-commands.md`](references/setup-commands.md) — copy-paste commands (bundled with this skill).
 - [`docs/agent-setup.md`](../../docs/agent-setup.md) — human walkthrough with diagrams, the three moving parts (config switcher / proxy / agent runtime), and recovery.

--- a/skills/acp-builder-setup/SKILL.md
+++ b/skills/acp-builder-setup/SKILL.md
@@ -32,7 +32,7 @@ This installs the demo skills into the runtime. It only copies or links files â€
 no global config is touched.
 
 Use this repo as the source of truth. Prefer symlinks for local development and
-copies for one-off installs. For exact commands, read `references/setup-commands.md`.
+copies for one-off installs. For exact commands, read [`references/setup-commands.md`](references/setup-commands.md).
 
 Do not assume repo-scoped `.agents/skills` or `.claude/skills` folders exist.
 This repo keeps canonical skills directly under `skills/`, then installs or links
@@ -45,8 +45,8 @@ Install these local-execution skills for Codex CLI/Desktop and Claude Code:
 
 Install these Claude Desktop upload packages:
 
-- `packages/claude-desktop/acp-builder-setup.zip`
-- `packages/claude-desktop/acp-paid-subscription-checkout.zip`
+- [`packages/claude-desktop/acp-builder-setup.zip`](../../packages/claude-desktop/acp-builder-setup.zip)
+- [`packages/claude-desktop/acp-paid-subscription-checkout.zip`](../../packages/claude-desktop/acp-paid-subscription-checkout.zip)
 
 In Claude Desktop, the combined checkout skill must use handoff or evidence-review
 mode unless the user has a separate local-tool bridge. Live checkout execution

--- a/skills/acp-builder-setup/references/setup-commands.md
+++ b/skills/acp-builder-setup/references/setup-commands.md
@@ -115,7 +115,7 @@ If a `restore` cannot run, see "Recovering Your Original Config" in
 
 Claude Desktop cannot use `ccr`/the proxy. Upload these ZIPs from Claude settings instead:
 
-- `packages/claude-desktop/acp-builder-setup.zip`
-- `packages/claude-desktop/acp-paid-subscription-checkout.zip`
+- [`packages/claude-desktop/acp-builder-setup.zip`](../../../packages/claude-desktop/acp-builder-setup.zip)
+- [`packages/claude-desktop/acp-paid-subscription-checkout.zip`](../../../packages/claude-desktop/acp-paid-subscription-checkout.zip)
 
 After upload, enable each skill in Claude's Skills settings.

--- a/skills/acp-builder-setup/references/setup-commands.md
+++ b/skills/acp-builder-setup/references/setup-commands.md
@@ -1,18 +1,80 @@
 # ACP Builder Setup Commands
 
-## Symlink Skills For Local Development
+Two jobs: install the skill (required), and optionally route through Virtuals for
+free credits (reversible — see the on/off lifecycle below). Run everything from
+the repo root unless noted.
+
+## 1. Install the ACP skill (required)
+
+Symlink for local development (edits picked up by both runtimes):
 
 ```bash
 scripts/install-local-skills.sh --mode symlink --target both
 ```
 
-## Copy Skills For One-Off Installs
+Copy for one-off installs:
 
 ```bash
 scripts/install-local-skills.sh --mode copy --target both
 ```
 
-## Codex Virtuals Proxy
+## 2. (Optional) Route through Virtuals for free credits
+
+Routing ON = the agent spends **Virtuals credits**; routing OFF = back on your
+**own account**. Set `VIRTUALS_API_KEY` in the shell first. The `make` targets
+are the simple path — they wrap the scripts and handle restart/proxy/restore.
+
+```
+                make claude-on / make codex-on
+   YOUR ACCOUNT ──────────────────────────────▶ VIRTUALS CREDITS
+                ◀──────────────────────────────
+                make claude-off / make codex-off
+```
+
+### Claude Code
+
+```
+make claude-on   →  ccr code  →  make claude-off
+[turn ON]           [use it]      [back to your account]
+```
+
+```bash
+# one-time installs
+npm install -g @anthropic-ai/claude-code
+npm install -g @musistudio/claude-code-router
+
+export VIRTUALS_API_KEY=...
+make claude-on      # activate Virtuals routing, validate, restart ccr
+ccr code            # use Claude Code on Virtuals credits
+make claude-check   # (read-only) validate the active router config
+make claude-off     # restore your previous config, restart ccr
+```
+
+### Codex
+
+```
+make codex-on   →  codex  →  make codex-off
+[turn ON +          [use]      [back to your account
+ start proxy]                  + stop proxy]
+```
+
+```bash
+export VIRTUALS_API_KEY=...
+make codex-on       # start the local proxy (background) + point Codex at it
+codex               # start a FRESH thread so it picks up the new provider
+make codex-off      # restore your previous Codex config + stop the proxy
+make codex-proxy    # alt: run the proxy in the foreground to watch logs
+```
+
+Run `make help` to list every target.
+
+## Advanced / custom model
+
+The `make` targets call these scripts. Use them directly only for a non-default
+model, the proxy in the foreground, or manual recovery. For choosing model ids,
+see [`docs/model-config.md`](../../../docs/model-config.md).
+
+Codex proxy in the foreground (instead of `make codex-on`'s background proxy):
 
 ```bash
 cd utilities/model-routing/codex-virtuals-proxy
@@ -21,13 +83,7 @@ cp .env.example .env
 npm start
 ```
 
-In another terminal from the repo root, activate Codex routing through the local proxy:
-
-```bash
-scripts/configure-codex-virtuals.mjs virtuals
-```
-
-This updates `~/.codex/config.toml` to use:
+`make codex-on` writes this block to `~/.codex/config.toml`:
 
 ```toml
 model = "gpt-5.5"
@@ -39,50 +95,25 @@ base_url = "http://127.0.0.1:8787/v1"
 wire_api = "responses"
 ```
 
-The Codex config uses the ChatGPT/Codex-supported `gpt-5.5` model id. The local proxy translates it to the Virtuals upstream model id `openai-gpt-55` when forwarding requests.
+The Codex config uses the Codex-supported `gpt-5.5` model id; the local proxy
+translates it to the Virtuals upstream id `openai-gpt-55` when forwarding.
 
-Restore the previous Codex model/provider after the demo:
-
-```bash
-scripts/configure-codex-virtuals.mjs restore
-```
-
-If no restore state exists, switch back to built-in Codex routing:
+Direct config-switcher verbs (both agents support `virtuals | restore | default | check`):
 
 ```bash
-scripts/configure-codex-virtuals.mjs default
+scripts/configure-codex-virtuals.mjs restore     # exact previous model/provider
+scripts/configure-codex-virtuals.mjs default     # built-in Codex routing (no restore state)
+
+scripts/configure-claude-virtuals.mjs restore && ccr restart   # previous provider/routes
+scripts/configure-claude-virtuals.mjs default && ccr restart   # remove Virtuals routes
 ```
 
-## Claude Code Virtuals Router
-
-```bash
-npm install -g @anthropic-ai/claude-code
-npm install -g @musistudio/claude-code-router
-
-export VIRTUALS_API_KEY=...
-scripts/configure-claude-virtuals.mjs virtuals
-scripts/configure-claude-virtuals.mjs check
-ccr restart
-ccr code
-```
-
-Restore the previous Claude Code Router provider/routes after the demo:
-
-```bash
-scripts/configure-claude-virtuals.mjs restore
-ccr restart
-```
-
-If no restore state exists, remove the Virtuals provider/routes:
-
-```bash
-scripts/configure-claude-virtuals.mjs default
-ccr restart
-```
+If a `restore` cannot run, see "Recovering Your Original Config" in
+[`docs/agent-setup.md`](../../../docs/agent-setup.md).
 
 ## Claude Desktop Upload
 
-Upload these ZIPs from Claude settings:
+Claude Desktop cannot use `ccr`/the proxy. Upload these ZIPs from Claude settings instead:
 
 - `packages/claude-desktop/acp-builder-setup.zip`
 - `packages/claude-desktop/acp-paid-subscription-checkout.zip`

--- a/skills/acp-builder-setup/references/setup-commands.md
+++ b/skills/acp-builder-setup/references/setup-commands.md
@@ -27,14 +27,14 @@ account. Fully reversible.
 
 ### Prerequisites
 
-1. **Set your Virtuals API key in the shell** (the `make` targets and the proxy
-   inherit it from here):
+1. **Get a Virtuals API key** from [app.virtuals.io](https://app.virtuals.io/).
+2. **Set it in your shell** (the `make` targets and the proxy inherit it from here):
 
    ```bash
    export VIRTUALS_API_KEY=...
    ```
 
-2. **Install the tooling for your agent:**
+3. **Install the tooling for your agent:**
 
    ```bash
    # Claude Code

--- a/skills/acp-builder-setup/references/setup-commands.md
+++ b/skills/acp-builder-setup/references/setup-commands.md
@@ -1,8 +1,10 @@
 # ACP Builder Setup Commands
 
-Two jobs: install the skill (required), and optionally route through Virtuals for
-free credits (reversible — see the on/off lifecycle below). Run everything from
-the repo root unless noted.
+The first-time runbook. Two jobs: install the skill (required), then optionally
+route through Virtuals for free credits. For how routing *works* — diagrams, the
+three moving parts (config switcher / proxy / runtime), and recovery — see
+[`docs/agent-setup.md`](../../../docs/agent-setup.md). Run everything from the repo
+root unless noted.
 
 ## 1. Install the ACP skill (required)
 
@@ -20,30 +22,29 @@ scripts/install-local-skills.sh --mode copy --target both
 
 ## 2. (Optional) Route through Virtuals for free credits
 
-Routing ON = the agent spends **Virtuals credits**; routing OFF = back on your
-**own account**. Set `VIRTUALS_API_KEY` in the shell first. The `make` targets
-are the simple path — they wrap the scripts and handle restart/proxy/restore.
+Routing **ON** = the agent spends Virtuals credits; **OFF** = back on your own
+account. Fully reversible.
 
-```
-                make claude-on / make codex-on
-   YOUR ACCOUNT ──────────────────────────────▶ VIRTUALS CREDITS
-                ◀──────────────────────────────
-                make claude-off / make codex-off
-```
+### Prerequisites
+
+1. **Set your Virtuals API key in the shell** (the `make` targets and the proxy
+   inherit it from here):
+
+   ```bash
+   export VIRTUALS_API_KEY=...
+   ```
+
+2. **Install the tooling for your agent:**
+
+   ```bash
+   # Claude Code
+   npm install -g @anthropic-ai/claude-code @musistudio/claude-code-router
+   # Codex: install the Codex CLI
+   ```
 
 ### Claude Code
 
-```
-make claude-on   →  ccr code  →  make claude-off
-[turn ON]           [use it]      [back to your account]
-```
-
 ```bash
-# one-time installs
-npm install -g @anthropic-ai/claude-code
-npm install -g @musistudio/claude-code-router
-
-export VIRTUALS_API_KEY=...
 make claude-on      # activate Virtuals routing, validate, restart ccr
 ccr code            # use Claude Code on Virtuals credits
 make claude-check   # (read-only) validate the active router config
@@ -52,64 +53,17 @@ make claude-off     # restore your previous config, restart ccr
 
 ### Codex
 
-```
-make codex-on   →  codex  →  make codex-off
-[turn ON +          [use]      [back to your account
- start proxy]                  + stop proxy]
-```
-
 ```bash
-export VIRTUALS_API_KEY=...
 make codex-on       # start the local proxy (background) + point Codex at it
 codex               # start a FRESH thread so it picks up the new provider
 make codex-off      # restore your previous Codex config + stop the proxy
 make codex-proxy    # alt: run the proxy in the foreground to watch logs
 ```
 
-Run `make help` to list every target.
-
-## Advanced / custom model
-
-The `make` targets call these scripts. Use them directly only for a non-default
-model, the proxy in the foreground, or manual recovery. For choosing model ids,
-see [`docs/model-config.md`](../../../docs/model-config.md).
-
-Codex proxy in the foreground (instead of `make codex-on`'s background proxy):
-
-```bash
-cd utilities/model-routing/codex-virtuals-proxy
-cp .env.example .env
-# edit .env and set VIRTUALS_API_KEY
-npm start
-```
-
-`make codex-on` writes this block to `~/.codex/config.toml`:
-
-```toml
-model = "gpt-5.5"
-model_provider = "virtuals_proxy"
-
-[model_providers.virtuals_proxy]
-name = "Virtuals via local Responses proxy"
-base_url = "http://127.0.0.1:8787/v1"
-wire_api = "responses"
-```
-
-The Codex config uses the Codex-supported `gpt-5.5` model id; the local proxy
-translates it to the Virtuals upstream id `openai-gpt-55` when forwarding.
-
-Direct config-switcher verbs (both agents support `virtuals | restore | default | check`):
-
-```bash
-scripts/configure-codex-virtuals.mjs restore     # exact previous model/provider
-scripts/configure-codex-virtuals.mjs default     # built-in Codex routing (no restore state)
-
-scripts/configure-claude-virtuals.mjs restore && ccr restart   # previous provider/routes
-scripts/configure-claude-virtuals.mjs default && ccr restart   # remove Virtuals routes
-```
-
-If a `restore` cannot run, see the "Recover" section of
-[`docs/agent-setup.md`](../../../docs/agent-setup.md).
+Run `make help` to list every target. For a non-default model, manual recovery,
+or how routing works under the hood, see
+[`docs/agent-setup.md`](../../../docs/agent-setup.md) and
+[`docs/model-config.md`](../../../docs/model-config.md).
 
 ## Claude Desktop Upload
 

--- a/skills/acp-builder-setup/references/setup-commands.md
+++ b/skills/acp-builder-setup/references/setup-commands.md
@@ -108,7 +108,7 @@ scripts/configure-claude-virtuals.mjs restore && ccr restart   # previous provid
 scripts/configure-claude-virtuals.mjs default && ccr restart   # remove Virtuals routes
 ```
 
-If a `restore` cannot run, see "Recovering Your Original Config" in
+If a `restore` cannot run, see the "Recover" section of
 [`docs/agent-setup.md`](../../../docs/agent-setup.md).
 
 ## Claude Desktop Upload


### PR DESCRIPTION
## Summary

Follow-up to #15. That PR added the `make` routing lifecycle but nothing referenced it, and the skill/docs were "on-heavy" — they explained how to turn Virtuals routing **on** but left teardown and the conceptual model unclear. This reframes the builder-setup skill and docs around that lifecycle and clarifies the one thing that confused everyone: when routing is on, you're spending **Virtuals credits, not your own account**.

## What changed

- **`skills/acp-builder-setup/SKILL.md`** — split into two clearly-scoped flows: **1. Install the ACP skill (required)** vs **2. (Optional) Route through Virtuals**. The skill now points at the `make` lifecycle, **confirms before mutating** global config, and always offers teardown. Trimmed to behavior-only (no duplicated command lists/diagrams).
- **`skills/acp-builder-setup/references/setup-commands.md`** — now the **first-time runbook**: prerequisites (get key from [app.virtuals.io](https://app.virtuals.io/) → export → install tooling) then the linear happy-path commands.
- **`docs/agent-setup.md`** — now the **how-it-works reference**: Mermaid `on → use → off → recover` diagrams, a "three moving parts" table (config switcher / proxy / runtime), and a new **"What `VIRTUALS_API_KEY` is for"** note (it authenticates to `compute.virtuals.io`; the router/proxy just carry it).
- **`README.md`** — discoverable `make` lifecycle pointer.

## Role split (no more overlap)

| File | Role | Diagrams |
| --- | --- | --- |
| `SKILL.md` | how the agent should behave | — |
| `references/setup-commands.md` | first-time runbook | — |
| `docs/agent-setup.md` | how-it-works reference | Mermaid ×2 |

## Notes / follow-ups

- Detailed API-key acquisition steps to come; for now the runbook links [app.virtuals.io](https://app.virtuals.io/).
- Docs-only change — no edits to the scripts/Makefile mechanism from #15.
- `packages/claude-desktop/acp-builder-setup.zip` still bundles the old SKILL.md; can repackage in a follow-up if desired.
