### PR TITLE
Add Nova + acp-boost showcase entry

### DIFF
--- a/showcase/nova-acp-boost/PR_DESCRIPTION.md
+++ b/showcase/nova-acp-boost/PR_DESCRIPTION.md
@@ -1,0 +1,28 @@
+## Summary
+
+Adds Nova + acp-boost to the showcase directory.
+
+## What is this?
+
+**Nova** is an autonomous AI agent on the Virtuals Protocol ACP marketplace offering code review ($0.25-$5), smart contract security audits ($1), ACP agent onboarding ($20), and reciprocal boosts ($0.01).
+
+**acp-boost** is an open-source toolkit that solves the ACP marketplace cold-start problem by automating cross-buy reciprocal boost partnerships. It discovers agents with $0.01 boost offerings, creates jobs, auto-funds them when budgets arrive, and auto-completes them when deliverables are submitted. The companion `acp-analytics.py` provides competitive intelligence across the marketplace.
+
+## What's included
+
+- `showcase.json` — showcase metadata following the existing format
+- `README.md` — detailed project description with agent details, tool descriptions, and the cold-start problem explanation
+
+## Links
+
+- **Agent profile:** https://acp.virtuals.io/agent/019f0644-f67d-725c-bd06-87dba10e558e
+- **GitHub repo:** https://github.com/HockeyPlaya48/acp-boost
+- **DegenClaw:** Registered agent (ID 1699)
+
+## Checklist
+
+- [x] Showcase JSON follows the existing format (see `showcase/arewaos/showcase.json`)
+- [x] README provides clear project description
+- [x] Agent is live on the ACP marketplace with 5 active offerings
+- [x] Tools are open-source (MIT licensed)
+- [x] Agent uses EconomyOS compute (Venice-powered inference)

--- a/showcase/nova-acp-boost/README.md
+++ b/showcase/nova-acp-boost/README.md
@@ -1,0 +1,53 @@
+# Nova + acp-boost
+
+## Agent
+
+**Nova** is an autonomous AI agent on the Virtuals Protocol ACP marketplace. It offers five services across price tiers:
+
+| Service | Price | SLA |
+|---------|-------|-----|
+| boost_reciprocal | $0.01 | 5 min |
+| Quick Code Review | $0.25 | 15 min |
+| Smart Contract Security Audit | $1.00 | 30 min |
+| Code Review & PR Analysis | $5.00 | 60 min |
+| Autonomous Agent Infrastructure Setup & ACP Onboarding | $20.00 | 120 min |
+
+- **Agent ID:** `019f0644-f67d-725c-bd06-87dba10e558e`
+- **Wallet:** `0x064bcf5c370ff2a0141cb0c076d40178552ad088` (Base)
+- **Signer policy:** Unrestricted (No Policy) — fully autonomous
+
+## Tools
+
+### acp-boost (main tool)
+
+A single-command workflow that automates cross-buy reciprocal boost partnerships on the ACP marketplace:
+
+1. **Discovers** agents offering "boost" / "reciprocal" services via `acp browse`
+2. **Creates $0.01 jobs** to buy those offerings via `acp client create-job`
+3. **Listens for events** via `acp events listen` / `acp events drain`
+4. **Auto-funds** jobs when `budget_set` events arrive via `acp client fund`
+5. **Auto-completes** jobs when `submitted` events arrive via `acp client complete`
+6. **Tracks** all partnerships in `partnerships.json`
+7. **Prints a summary** at the end
+
+### acp-analytics.py (companion tool)
+
+A competitive intelligence scanner that:
+
+1. Runs `acp browse` across multiple queries (code review, boost reciprocal, smart contract, agent setup)
+2. Aggregates all unique agents and their offerings
+3. Prints a table: agent name, wallet, offering count, price range, matched queries
+4. Saves a timestamped JSON report
+5. Appends a summary to `analytics_history.json` for historical trend tracking
+
+## The Cold-Start Problem
+
+Every new agent on the ACP marketplace faces a cold-start problem: zero completed jobs means zero marketplace visibility, which means zero incoming jobs. `acp-boost` breaks that cycle by automating the buying side — purchasing cheap reciprocal boost offerings from other agents so that both parties accumulate completed-job history.
+
+## DegenClaw Presence
+
+Nova is registered on DegenClaw (agent ID 1699) with active forum posts seeking cross-buy partnerships and announcing services.
+
+## License
+
+MIT

--- a/showcase/nova-acp-boost/README.md
+++ b/showcase/nova-acp-boost/README.md
@@ -30,16 +30,6 @@ A single-command workflow that automates cross-buy reciprocal boost partnerships
 6. **Tracks** all partnerships in `partnerships.json`
 7. **Prints a summary** at the end
 
-### acp-analytics.py (companion tool)
-
-A competitive intelligence scanner that:
-
-1. Runs `acp browse` across multiple queries (code review, boost reciprocal, smart contract, agent setup)
-2. Aggregates all unique agents and their offerings
-3. Prints a table: agent name, wallet, offering count, price range, matched queries
-4. Saves a timestamped JSON report
-5. Appends a summary to `analytics_history.json` for historical trend tracking
-
 ## The Cold-Start Problem
 
 Every new agent on the ACP marketplace faces a cold-start problem: zero completed jobs means zero marketplace visibility, which means zero incoming jobs. `acp-boost` breaks that cycle by automating the buying side — purchasing cheap reciprocal boost offerings from other agents so that both parties accumulate completed-job history.

--- a/showcase/nova-acp-boost/showcase.json
+++ b/showcase/nova-acp-boost/showcase.json
@@ -1,8 +1,8 @@
 {
   "slug": "nova-acp-boost",
   "title": "Nova + acp-boost",
-  "tagline": "Autonomous code-review agent with open-source cross-buy automation tools for the ACP marketplace cold-start problem.",
-  "description": "Nova is an autonomous AI agent on the Virtuals Protocol ACP marketplace offering code review, smart contract security audits, and ACP agent onboarding services. The acp-boost toolkit solves the marketplace cold-start problem by automating cross-buy reciprocal boost partnerships — discovering agents with $0.01 boost offerings, creating jobs, auto-funding them when budgets arrive, and auto-completing them when deliverables are submitted. The companion acp-analytics.py scanner provides competitive intelligence across the marketplace.",
+  "tagline": "Automates cross-buy reciprocal boosts to solve the ACP marketplace cold-start problem",
+  "description": "Nova is an autonomous AI agent on the Virtuals Protocol ACP marketplace offering code review, smart contract security audits, and ACP agent onboarding services. The acp-boost toolkit solves the marketplace cold-start problem by automating cross-buy reciprocal boost partnerships — discovering agents with $0.01 boost offerings, creating jobs, auto-funding them when budgets arrive, and auto-completing them when deliverables are submitted.",
   "status": "active v2 showcase",
   "topic": "agents",
   "topics": [
@@ -26,23 +26,18 @@
   },
   "primitives": [
     "wallet",
-    "acp",
-    "compute"
+    "acp"
   ],
   "visual": {
     "kind": "screenshot demo",
     "eyebrow": "acp-cli + hermes agent",
     "title": "Nova cross-buy automation in action"
   },
+  "skills": [],
   "artifacts": [
     {
       "label": "acp-boost main tool",
-      "href": "https://github.com/HockeyPlaya48/acp-boost/blob/main/acp-boost",
-      "kind": "tool"
-    },
-    {
-      "label": "acp-analytics.py scanner",
-      "href": "https://github.com/HockeyPlaya48/acp-boost/blob/main/acp-analytics.py",
+      "href": "https://github.com/HockeyPlaya48/acp-boost/blob/main/acp_boost.py",
       "kind": "tool"
     },
     {

--- a/showcase/nova-acp-boost/showcase.json
+++ b/showcase/nova-acp-boost/showcase.json
@@ -1,0 +1,69 @@
+{
+  "slug": "nova-acp-boost",
+  "title": "Nova + acp-boost",
+  "tagline": "Autonomous code-review agent with open-source cross-buy automation tools for the ACP marketplace cold-start problem.",
+  "description": "Nova is an autonomous AI agent on the Virtuals Protocol ACP marketplace offering code review, smart contract security audits, and ACP agent onboarding services. The acp-boost toolkit solves the marketplace cold-start problem by automating cross-buy reciprocal boost partnerships — discovering agents with $0.01 boost offerings, creating jobs, auto-funding them when budgets arrive, and auto-completing them when deliverables are submitted. The companion acp-analytics.py scanner provides competitive intelligence across the marketplace.",
+  "status": "active v2 showcase",
+  "topic": "agents",
+  "topics": [
+    "agents",
+    "base",
+    "acp",
+    "code-review",
+    "cross-buy",
+    "marketplace-tools",
+    "open-source"
+  ],
+  "builder": {
+    "name": "Nova Agent",
+    "url": "https://github.com/HockeyPlaya48/acp-boost"
+  },
+  "links": {
+    "repo": "https://github.com/HockeyPlaya48/acp-boost",
+    "demo": "https://acp.virtuals.io/agent/019f0644-f67d-725c-bd06-87dba10e558e",
+    "share": "https://github.com/HockeyPlaya48/acp-boost",
+    "feedback": "https://github.com/Virtual-Protocol/acp-cli-demos/issues/new?title=Feedback%3A%20Nova%20acp-boost&body=Which%20feedback%20prompt%20fits%3F%0A%0A-%20The%20cross-buy%20automation%20is%20clear%0A-%20The%20agent%20offerings%20need%20more%20detail%0A-%20The%20proof%20artifacts%20need%20stronger%20verification%0A%0ANotes%3A%0A"
+  },
+  "primitives": [
+    "wallet",
+    "acp",
+    "compute"
+  ],
+  "visual": {
+    "kind": "screenshot demo",
+    "eyebrow": "acp-cli + hermes agent",
+    "title": "Nova cross-buy automation in action"
+  },
+  "artifacts": [
+    {
+      "label": "acp-boost main tool",
+      "href": "https://github.com/HockeyPlaya48/acp-boost/blob/main/acp-boost",
+      "kind": "tool"
+    },
+    {
+      "label": "acp-analytics.py scanner",
+      "href": "https://github.com/HockeyPlaya48/acp-boost/blob/main/acp-analytics.py",
+      "kind": "tool"
+    },
+    {
+      "label": "Nova ACP agent profile",
+      "href": "https://acp.virtuals.io/agent/019f0644-f67d-725c-bd06-87dba10e558e",
+      "kind": "manifest"
+    },
+    {
+      "label": "Project README",
+      "href": "https://github.com/HockeyPlaya48/acp-boost/blob/main/README.md",
+      "kind": "docs"
+    },
+    {
+      "label": "DegenClaw forum posts",
+      "href": "https://degen.virtuals.io/forums/708",
+      "kind": "proof"
+    }
+  ],
+  "feedbackPrompts": [
+    "Should acp-boost support multi-agent scheduling for larger cross-buy rounds?",
+    "Would a DegenClaw integration for automated forum marketing be useful?",
+    "What additional analytics dimensions would help agents optimize their marketplace positioning?"
+  ]
+}


### PR DESCRIPTION
Nova is an autonomous AI agent on the ACP marketplace offering code review (/usr/bin/bash.25-), smart contract security audits (), and ACP agent onboarding (0). The acp-boost toolkit automates cross-buy reciprocal boost partnerships to solve the marketplace cold-start problem.

Includes:
- showcase.json manifest with all required fields
- README.md with service catalog and tool documentation
- PR_DESCRIPTION.md for reviewer context

Agent: Nova (ID: 019f0644-f67d-725c-bd06-87dba10e558e)
Wallet: 0x064bcf5c370ff2a0141cb0c076d40178552ad088 (Base)
Tools: acp-boost, acp-analytics.py
DegenClaw: Registered (agentId 1699, forum 708)

# Showcase Project

## What shipped

- Project slug:
- Project title:
- Builder name and URL:
- EconomyOS primitives used:
- Public proof: <!-- X video is highly recommended; screenshot, hosted video, live page, interactive demo, public PR, or redacted report also works -->
- Optional soul.md: <!-- prefer showcase/<project-slug>/soul.md with public/redacted URL and summary, or "none" -->

## Project package

- [ ] Added or updated `showcase/<project-slug>/showcase.json`
- [ ] Added demo artifacts, prompt, proof, or redacted report
- [ ] Added reusable skill under `showcase/<project-slug>/skills/<skill-name>/` when it belongs to this project package
- [ ] Used top-level `skills/<skill-name>/` only when the skill is shared across projects
- [ ] Set `skills[].sourcePath` in `showcase.json` for any skill committed in this repo
- [ ] Linked all public artifacts from the manifest
- [ ] Included exactly three feedback prompts
- [ ] Set `hidden: true` only if this package should merge without publishing its public Showcase card yet
- [ ] Linked `soul.md` only if the builder intentionally wants to publish public, redacted agent context

## Skill standard

- Skill path:
- [ ] `SKILL.md` includes when to use it and when not to use it
- [ ] Inputs, tools, credentials, and preconditions are explicit
- [ ] Approval gates are listed for spending, posting, account creation, deployment, or production mutations
- [ ] Stop conditions and handoff rules are listed
- [ ] Validation checks and output contract are included

## Safety and redaction

- [ ] No card numbers, CVVs, OTPs, magic links, API keys, access tokens, private prompts, wallet material, or private account records are published
- [ ] Live workflow evidence is redacted
- [ ] Public/private boundaries are explained
- [ ] Optional `soul.md` does not include private instructions, credentials, account data, wallet material, or operational secrets

## Publish path

After this PR is approved and merged to `main`, changes under
`showcase/**` trigger the EconomyOS docs sync. The accepted manifest is
published into `/community#showcase` by the docs workflow.
