### PR TITLE
Add Hatcher Virtuals ACP Workbench showcase

### DIFF
--- a/showcase/hatcher-virtuals-acp-workbench/README.md
+++ b/showcase/hatcher-virtuals-acp-workbench/README.md
@@ -1,0 +1,57 @@
+# Hatcher Virtuals ACP Workbench
+
+Hatcher Virtuals ACP Workbench is a managed agent-control surface for using Virtuals from inside Hatcher.
+
+The demo shows a Hatcher-managed agent moving through the Virtuals integration:
+
+1. Select Virtuals as an inference provider from the agent configuration page.
+2. Open the agent wallet provider area and enable Virtuals access.
+3. Set review-first access and budget controls.
+4. Search the Virtuals ACP marketplace for provider agents.
+5. Select a provider offering and prepare an ACP job draft.
+6. Inspect HatcherLabs service packaging for publishing Hatcher-managed capabilities into ACP.
+
+The workbench is designed to add demand and execution volume to the Virtuals agent economy without replacing Virtuals Console. Hatcher keeps the operator-facing control layer, while Virtuals supplies the Compute and ACP marketplace primitives.
+
+## Demo Video
+
+- YouTube: https://youtu.be/DvtjysrHfzs
+
+The video shows the Hatcher site, the Virtuals provider selection surface, Virtuals access controls, ACP provider search, job-draft preparation, and the HatcherLabs services area.
+
+## Where The Integration Lives
+
+- Virtuals inference models: `Hatcher Dashboard -> Agent -> Config -> Provider / Model -> Virtuals`
+- ACP jobs, access controls, budget controls, and HatcherLabs services: `Hatcher Dashboard -> Agent -> Wallet -> Virtuals`
+
+## What The Workbench Does
+
+- Routes agent inference through Virtuals Compute from Hatcher-managed agents.
+- Gives each agent a visible Virtuals access switch before ACP matching or drafting.
+- Sets operator-controlled daily and per-job budget limits.
+- Searches the Virtuals ACP marketplace for provider agents and offerings.
+- Prepares reviewed ACP job drafts that show provider, offering, budget, and command-plan context.
+- Packages selected HatcherLabs capabilities as ACP offerings that can be prepared and published through the Virtuals operator path.
+- Keeps sensitive API keys, private wallet material, and runtime credentials out of the public UI and public showcase artifacts.
+
+## Review-First Boundary
+
+This showcase intentionally demonstrates a review-first flow. The Hatcher UI prepares and displays the ACP job draft before a funded action is executed. Operators can inspect provider identity, offering name, maximum budget, requirements, and command plan before approving any live ACP action.
+
+The public proof does not include private API keys, private prompts, full internal job records, wallet private material, OTPs, access tokens, or user account data.
+
+## Package Contents
+
+- `showcase.json` - card-ready EconomyOS Showcase manifest.
+- `soul.md` - public/redacted HatcherLabs agent context and boundaries.
+- `examples/prompt.md` - reusable demo prompt for running the workbench flow.
+- `examples/result-redacted.md` - redacted result report from the public demo.
+- `skills/hatcher-virtuals-acp-workbench/SKILL.md` - reusable operator skill for running this workflow safely.
+
+## Links
+
+- Hatcher: https://hatcher.host
+- Demo video: https://youtu.be/DvtjysrHfzs
+- Virtuals ACP Scan: https://app.virtuals.io/acp/scan
+
+Built by Hatcher Labs for the Virtuals agent economy.

--- a/showcase/hatcher-virtuals-acp-workbench/examples/prompt.md
+++ b/showcase/hatcher-virtuals-acp-workbench/examples/prompt.md
@@ -1,0 +1,30 @@
+# Demo Prompt
+
+Use the Hatcher Virtuals ACP Workbench to prepare a reviewed ACP job draft.
+
+Goal:
+
+- use a Hatcher-managed agent,
+- select Virtuals as the inference provider,
+- enable Virtuals access,
+- search ACP providers for an agent audit or market-research task,
+- select one provider offering,
+- prepare a draft only,
+- and report the provider, offering, maximum budget, requirements, and next approval step.
+
+Suggested task brief:
+
+```text
+Find a Virtuals ACP provider that can review an agent launch or perform a short market-research task. Prefer providers with clear offerings and low fixed pricing. Prepare a reviewed ACP job draft, but do not fund or submit the job until an operator approves it.
+```
+
+Expected output:
+
+- selected provider name,
+- selected offering name,
+- max budget,
+- requirement payload summary,
+- Hatcher job-draft status,
+- approval gate before live ACP execution.
+
+Do not include private API keys, wallet private material, OTPs, full access tokens, private prompts, or user account records in the final report.

--- a/showcase/hatcher-virtuals-acp-workbench/examples/result-redacted.md
+++ b/showcase/hatcher-virtuals-acp-workbench/examples/result-redacted.md
@@ -1,0 +1,57 @@
+# Hatcher Virtuals ACP Workbench - Redacted Result Report
+
+## Public Proof
+
+- Demo video: https://youtu.be/DvtjysrHfzs
+- Builder: Hatcher Labs
+- Site: https://hatcher.host
+- Public ACP explorer: https://app.virtuals.io/acp/scan
+
+## Flow Captured
+
+1. Opened a Hatcher-managed agent.
+2. Confirmed Virtuals appears as an inference provider in agent configuration.
+3. Opened `Wallet -> Virtuals`.
+4. Used the Virtuals access and budget-control panel.
+5. Searched the Virtuals ACP marketplace for providers.
+6. Reviewed ACP provider and offering information.
+7. Prepared a review-first job draft rather than executing a funded ACP action immediately.
+8. Opened the HatcherLabs services area for service packaging and publish preparation.
+
+## Redacted Draft Shape
+
+```json
+{
+  "client": "Hatcher-managed agent",
+  "provider": {
+    "name": "[redacted provider display name from marketplace search]",
+    "walletAddress": "[redacted public wallet/address in video context]"
+  },
+  "offering": {
+    "name": "[redacted selected offering]",
+    "priceType": "fixed-or-marketplace-defined"
+  },
+  "budget": {
+    "maxPerJobUsd": "[operator-controlled limit]",
+    "dailyBudgetUsd": "[operator-controlled limit]"
+  },
+  "requirements": {
+    "task": "Find or review an agent/service candidate from the Virtuals ACP marketplace."
+  },
+  "status": "draft-prepared-for-review",
+  "approvalGate": "operator approval required before live funding or submission"
+}
+```
+
+## What Is Not Published
+
+- No private API keys.
+- No environment variables.
+- No private wallet keys or seed phrases.
+- No OTPs, magic links, or account recovery material.
+- No full private Hatcher user records.
+- No claim that the demo funded or settled a live ACP job.
+
+## Reviewer Notes
+
+The demo is intentionally review-first. It proves the Hatcher UI integration, Virtuals provider selection, ACP marketplace search, job-draft preparation, and HatcherLabs service-packaging surface. A later showcase can add live funding and provider delivery proof once the operator decides which HatcherLabs service should be fully published as the first production ACP offering.

--- a/showcase/hatcher-virtuals-acp-workbench/showcase.json
+++ b/showcase/hatcher-virtuals-acp-workbench/showcase.json
@@ -1,0 +1,83 @@
+{
+  "slug": "hatcher-virtuals-acp-workbench",
+  "title": "Hatcher Virtuals ACP Workbench",
+  "tagline": "A Hatcher-managed agent workbench for Virtuals Compute, ACP provider matching, review-first job drafts, and HatcherLabs service packaging.",
+  "description": "Hatcher Virtuals ACP Workbench shows a Hatcher-managed agent using Virtuals from its control layer: selecting Virtuals as an inference provider, enabling Virtuals access, setting budget controls, searching ACP providers, preparing a reviewed ACP job draft, and packaging HatcherLabs services for the same agent economy. The workflow is intentionally review-first: Hatcher surfaces provider, offering, budget, and command-plan context before an operator approves any funded ACP action.",
+  "status": "active showcase",
+  "topic": "agents",
+  "topics": [
+    "agents",
+    "hatcher",
+    "virtuals",
+    "acp",
+    "compute",
+    "marketplace"
+  ],
+  "builder": {
+    "name": "Hatcher Labs",
+    "url": "https://hatcher.host"
+  },
+  "links": {
+    "repo": "https://github.com/Virtual-Protocol/acp-cli-demos/tree/main/showcase/hatcher-virtuals-acp-workbench",
+    "demo": "https://youtu.be/DvtjysrHfzs",
+    "video": "https://youtu.be/DvtjysrHfzs",
+    "share": "https://youtu.be/DvtjysrHfzs",
+    "feedback": "https://github.com/Virtual-Protocol/acp-cli-demos/issues/new?title=Feedback%3A%20Hatcher%20Virtuals%20ACP%20Workbench&body=Which%20feedback%20prompt%20fits%3F%0A%0A-%20The%20Hatcher%20managed%20ACP%20flow%20is%20clear%0A-%20The%20review-first%20job%20draft%20needs%20more%20proof%0A-%20The%20HatcherLabs%20service%20packaging%20needs%20more%20detail%0A%0ANotes%3A%0A"
+  },
+  "primitives": [
+    "wallet",
+    "acp"
+  ],
+  "visual": {
+    "kind": "youtube demo video",
+    "eyebrow": "hatcher + virtuals + acp",
+    "title": "managed acp workbench",
+    "posterUrl": "https://img.youtube.com/vi/DvtjysrHfzs/maxresdefault.jpg",
+    "videoLabel": "Watch the Hatcher Virtuals ACP Workbench demo on YouTube"
+  },
+  "skills": [
+    {
+      "name": "hatcher-virtuals-acp-workbench",
+      "href": "https://github.com/Virtual-Protocol/acp-cli-demos/tree/main/showcase/hatcher-virtuals-acp-workbench/skills/hatcher-virtuals-acp-workbench",
+      "sourcePath": "showcase/hatcher-virtuals-acp-workbench/skills/hatcher-virtuals-acp-workbench",
+      "summary": "Reusable operator workflow for running a Hatcher-managed Virtuals ACP session: choose Virtuals Compute, enable access, match providers, prepare review-first job drafts, and package HatcherLabs services safely.",
+      "install": "cp -R showcase/hatcher-virtuals-acp-workbench/skills/hatcher-virtuals-acp-workbench ~/.agents/skills/\ncp -R showcase/hatcher-virtuals-acp-workbench/skills/hatcher-virtuals-acp-workbench ~/.claude/skills/"
+    }
+  ],
+  "artifacts": [
+    {
+      "label": "Hatcher Virtuals ACP Workbench demo video",
+      "href": "https://youtu.be/DvtjysrHfzs",
+      "kind": "video"
+    },
+    {
+      "label": "Showcase package README",
+      "href": "https://github.com/Virtual-Protocol/acp-cli-demos/blob/main/showcase/hatcher-virtuals-acp-workbench/README.md",
+      "kind": "docs"
+    },
+    {
+      "label": "Reusable workbench skill",
+      "href": "https://github.com/Virtual-Protocol/acp-cli-demos/tree/main/showcase/hatcher-virtuals-acp-workbench/skills/hatcher-virtuals-acp-workbench",
+      "kind": "skill"
+    },
+    {
+      "label": "Demo prompt",
+      "href": "https://github.com/Virtual-Protocol/acp-cli-demos/blob/main/showcase/hatcher-virtuals-acp-workbench/examples/prompt.md",
+      "kind": "docs"
+    },
+    {
+      "label": "Redacted result report",
+      "href": "https://github.com/Virtual-Protocol/acp-cli-demos/blob/main/showcase/hatcher-virtuals-acp-workbench/examples/result-redacted.md",
+      "kind": "proof"
+    }
+  ],
+  "soul": {
+    "href": "https://github.com/Virtual-Protocol/acp-cli-demos/blob/main/showcase/hatcher-virtuals-acp-workbench/soul.md",
+    "summary": "Public/redacted HatcherLabs agent context, user approval boundaries, and ACP workbench operating rules."
+  },
+  "feedbackPrompts": [
+    "Does the demo make the managed ACP provider matching flow clear?",
+    "Which HatcherLabs service should become the first fully live ACP offering?",
+    "What additional proof would make review-first ACP job drafting easier to trust?"
+  ]
+}

--- a/showcase/hatcher-virtuals-acp-workbench/skills/hatcher-virtuals-acp-workbench/SKILL.md
+++ b/showcase/hatcher-virtuals-acp-workbench/skills/hatcher-virtuals-acp-workbench/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: hatcher-virtuals-acp-workbench
+description: Run a Hatcher-managed Virtuals ACP session: select Virtuals Compute, enable access, match ACP providers, prepare review-first job drafts, and package HatcherLabs services without exposing secrets or funding jobs without approval.
+version: 1.0.0
+author: Hatcher Labs
+license: MIT
+---
+
+# Hatcher Virtuals ACP Workbench
+
+Use this skill when operating or reviewing the Hatcher x Virtuals integration from a Hatcher-managed agent.
+
+The skill is designed for review-first ACP work: the agent can search, match, prepare, and package, but live funding, publishing, or production mutation requires explicit operator approval.
+
+## When To Use
+
+- A Hatcher operator wants to route an agent through Virtuals-hosted inference.
+- A Hatcher operator wants to search the Virtuals ACP marketplace from the agent wallet panel.
+- A Hatcher operator wants to prepare an ACP job draft for review before funding or submission.
+- A Hatcher operator wants to package a HatcherLabs capability as a candidate ACP service.
+- A reviewer wants to verify that a public demo keeps secrets and private account data out of artifacts.
+
+## When Not To Use
+
+- Do not use this skill to bypass Virtuals Console, ACP CLI, or Hatcher approval controls.
+- Do not execute funded ACP jobs unless the operator explicitly approves provider, offering, requirements, and maximum spend.
+- Do not publish HatcherLabs services as ACP offerings without operator approval.
+- Do not expose API keys, access tokens, OTPs, wallet private keys, seed phrases, private prompts, runtime logs, or private user records.
+- Do not claim job completion, escrow, settlement, or provider delivery unless the proof artifact shows that exact step.
+
+## Required Inputs
+
+- Hatcher account access with permission to open the target agent.
+- Target Hatcher agent name or ID.
+- Task brief for the ACP provider search.
+- Maximum per-job budget and daily budget.
+- Whether the operator wants draft-only, live job execution, or HatcherLabs service publishing.
+- Public-safe proof target: video, screenshot, redacted report, or package README.
+
+## Tools And Credentials
+
+- Hatcher web UI at `https://hatcher.host`.
+- Optional Virtuals ACP explorer at `https://app.virtuals.io/acp/scan`.
+- Hatcher-managed Virtuals server key configured server-side by Hatcher.
+- No user should paste private API keys, seed phrases, or access tokens into the prompt or public artifacts.
+
+## Workflow
+
+1. Open the target Hatcher agent.
+2. Go to `Config -> Provider / Model`.
+3. Select `Virtuals` as the provider and choose the appropriate Virtuals-hosted model.
+4. Go to `Wallet -> Virtuals`.
+5. Turn on Virtuals access if it is off.
+6. Set daily and per-job budget controls.
+7. Use `Find help` to describe the task brief.
+8. Run provider matching or marketplace search.
+9. Inspect provider names, offerings, pricing, and fit.
+10. Select one provider offering.
+11. Prepare a job draft.
+12. Stop for operator review before any funded ACP action.
+13. If packaging HatcherLabs services, use the Hatcher services area to preview the publish payload before publishing.
+14. Produce a redacted report with provider, offering, budget, requirements summary, and approval status.
+
+## Approval Gates
+
+Stop and ask for explicit approval before:
+
+- enabling access on a production agent,
+- increasing budget limits,
+- creating or funding a live ACP job,
+- accepting an ACP provider job,
+- publishing a HatcherLabs service,
+- changing production model/provider configuration,
+- or publishing proof that includes sensitive or private context.
+
+Approval must name the provider/offering or service, maximum spend, and whether the operator wants draft-only or live execution.
+
+## Stop Conditions
+
+Stop without executing live actions if:
+
+- the provider identity, offering, or pricing is unclear,
+- the selected provider does not match the requested task,
+- the budget differs from operator authorization,
+- Hatcher access or Virtuals access is unavailable,
+- the UI exposes private account or credential data that would be captured in public proof,
+- an ACP command would fund, submit, publish, or mutate production state without approval,
+- or any output would reveal API keys, private wallet material, OTPs, access tokens, private prompts, or private account records.
+
+## Validation
+
+For a public showcase package:
+
+```bash
+node scripts/validate-showcase.mjs
+```
+
+For runtime evidence, verify:
+
+- the demo shows Virtuals as a provider in Hatcher,
+- the demo shows the Virtuals wallet panel,
+- access and budget controls are visible,
+- ACP provider search or matching is visible,
+- the job is presented as a reviewed draft unless live execution proof is included,
+- and all sensitive material is redacted.
+
+## Output Contract
+
+Return:
+
+- target Hatcher agent,
+- selected Virtuals model or provider state,
+- ACP search query,
+- selected provider and offering,
+- budget limits,
+- draft status or publish-preview status,
+- explicit approval gate before live execution,
+- public proof link or redacted artifact path,
+- and any reviewer caveats.

--- a/showcase/hatcher-virtuals-acp-workbench/soul.md
+++ b/showcase/hatcher-virtuals-acp-workbench/soul.md
@@ -1,0 +1,36 @@
+# HatcherLabs Agent Context
+
+HatcherLabs is the public Hatcher agent used to demonstrate a managed Virtuals ACP workflow from the Hatcher control layer.
+
+## Purpose
+
+The agent is used to show how a Hatcher-managed runtime can:
+
+- use Virtuals as an inference provider,
+- search the Virtuals ACP marketplace,
+- prepare review-first ACP job drafts,
+- expose Hatcher-managed capabilities as service packages,
+- and keep operator approval in front of live funded actions.
+
+## Public Boundaries
+
+- Do not publish private API keys, environment variables, access tokens, OTPs, magic links, wallet private keys, seed phrases, or private account records.
+- Do not claim an ACP job was funded, escrowed, or completed unless the proof artifact shows that exact step.
+- Treat draft creation as review-first preparation, not final settlement.
+- Keep provider matching explainable: provider name, offering, budget, requirements, and draft plan should be visible before approval.
+- Keep Hatcher user data and internal runtime logs out of public showcase artifacts unless explicitly redacted.
+
+## Approval Gates
+
+Explicit operator approval is required before:
+
+- enabling Virtuals access for a production agent,
+- increasing daily or per-job budget limits,
+- creating or funding a live ACP job,
+- publishing a HatcherLabs service as an ACP offering,
+- exposing a new public proof artifact,
+- or changing production agent configuration.
+
+## Review Preference
+
+The showcase favors concrete evidence over broad claims: a public video, redacted result report, visible Hatcher UI surfaces, inspectable manifest, and reusable skill.


### PR DESCRIPTION
## Showcase Project

## What shipped

- Project slug: `hatcher-virtuals-acp-workbench`
- Project title: Hatcher Virtuals ACP Workbench
- Builder name and URL: Hatcher Labs, https://hatcher.host
- EconomyOS primitives used: `wallet`, `acp`
- Public proof: https://youtu.be/DvtjysrHfzs
- Optional soul.md: `showcase/hatcher-virtuals-acp-workbench/soul.md` with public/redacted HatcherLabs agent context and approval boundaries

## Project package

- [x] Added or updated `showcase/<project-slug>/showcase.json`
- [x] Added demo artifacts, prompt, proof, or redacted report
- [x] Added reusable skill under `showcase/<project-slug>/skills/<skill-name>/` when it belongs to this project package
- [x] Used top-level `skills/<skill-name>/` only when the skill is shared across projects
- [x] Set `skills[].sourcePath` in `showcase.json` for any skill committed in this repo
- [x] Linked all public artifacts from the manifest
- [x] Included exactly three feedback prompts
- [x] Confirmed this package should publish publicly after merge, so `hidden` is not set
- [x] Linked `soul.md` only if the builder intentionally wants to publish public, redacted agent context

## Skill standard

- Skill path: `showcase/hatcher-virtuals-acp-workbench/skills/hatcher-virtuals-acp-workbench`
- [x] `SKILL.md` includes when to use it and when not to use it
- [x] Inputs, tools, credentials, and preconditions are explicit
- [x] Approval gates are listed for spending, posting, account creation, deployment, or production mutations
- [x] Stop conditions and handoff rules are listed
- [x] Validation checks and output contract are included

## Safety and redaction

- [x] No card numbers, CVVs, OTPs, magic links, API keys, access tokens, private prompts, wallet material, or private account records are published
- [x] Live workflow evidence is redacted
- [x] Public/private boundaries are explained
- [x] Optional `soul.md` does not include private instructions, credentials, account data, wallet material, or operational secrets

## Publish path

After this PR is approved and merged to `main`, changes under `showcase/**` trigger the EconomyOS docs sync. The accepted manifest is published into `/community#showcase` by the docs workflow.

## Validation

- `node scripts/validate-showcase.mjs` -> `Validated 8 showcase project manifest(s).`
- Repository routing utility syntax check passed
- Router example config parsed successfully
- Local skill installer checks passed for symlink and copy modes