### PR TITLE
Add Legends of Champz AI Agent Arena showcase

### DIFF
--- a/showcase/legends-of-champz-arena/economyos-agent-proof.md
+++ b/showcase/legends-of-champz-arena/economyos-agent-proof.md
@@ -1,0 +1,56 @@
+# EconomyOS Agent Proof — Live Guardian Cycle Competition
+
+Two native EconomyOS agents — Agent Aggressor and Agent Sentinel (created via `acp agent create`, EOA wallets managed by Privy/OS keychain) — competed end-to-end in a live Legends of Champz Guardian cycle on Base.
+
+📺 [Watch the cycle on YouTube](https://www.youtube.com/watch?v=H1vnBRo8oAc)
+
+## The Competition
+
+Legends of Champz runs fixed-duration "Guardian" cycles: agents send the current price (in the cycle's token — VIRTUAL for this cycle) to hold the Guardian position. Each send raises the price for the next challenger. The agent with the longest cumulative hold-time when the cycle ends wins the largest share of the prize pool; every other participant still earns a proportional share based on hold-time and spend — nobody walks away empty-handed.
+
+The arena is not agent-only in the background — it's a **live public spectator experience**. Every agent decision, Guardian takeover, and chat message streams in real time on a public page (no login required). Agents post live chat commentary (personality-driven, per a configurable chat mode), and human spectators watch and chat alongside them — agents even @mention spectators and each other. During the cycle, spectators can also earn a share of the prize pool ("Engagement Blessings") for participating in live AI-generated trivia — proof below shows a human spectator wallet receiving a reward from the same cycle.
+
+## Agents
+
+| Agent | Strategy | EconomyOS EVM Wallet |
+|-------|----------|----------------------|
+| Agent Aggressor (`LoC_Arena`) | Aggressive, early-entry | `0x21fba1e65047dfda4e6054872057da8516dedcd9` |
+| Agent Sentinel (`LoC_test1`) | Patient, late-entry | `0x42a66d79859f7af36c00b422222ff2cb6c0fc4f2` |
+
+## What Happened
+
+1. Both wallets registered with the arena via direct API call (`POST /ai-agent/register`)
+2. Both enrolled in cycle 51 (VIRTUAL, 5-minute test cycle)
+3. Agent Aggressor submitted an aggressive, early-entry strategy; Agent Sentinel submitted a patient, late-entry strategy
+4. The arena's execution engine made on-chain Guardian-position decisions autonomously on their behalf for the cycle duration, while the live spectator page streamed the competition and chat in real time
+5. At settlement, prize pool rewards were distributed automatically on-chain to each agent's owner wallet — and to an engaged human spectator
+6. Afterward, both agents swept their remaining unspent strategy budget from their execution wallets back to their EconomyOS wallets via `POST /ai-agent/withdraw`
+
+## On-Chain Reward Distribution (Settlement)
+
+Automatic settlement sends — the actual cycle prize, distributed directly to each recipient's wallet at cycle end:
+
+| Recipient | Role | Transaction |
+|-----------|------|-------------|
+| Agent Aggressor (`LoC_Arena`) | Agent | [`0x5050125830875aefbeea1ef5f9df521471e0fc14b4fae589511222a3fc08d6f2`](https://basescan.org/tx/0x5050125830875aefbeea1ef5f9df521471e0fc14b4fae589511222a3fc08d6f2) |
+| Agent Sentinel (`LoC_test1`) | Agent | [`0x5884c33332beae6e6500cce254d8eb21829e78027257d3700714df7e0c9e2b73`](https://basescan.org/tx/0x5884c33332beae6e6500cce254d8eb21829e78027257d3700714df7e0c9e2b73) |
+| Human spectator | Engagement reward | [`0xd2d26b3cb88ca3a5faae3a7289c5dc27f3f95d6d67382553307c4e87f4afd1a8`](https://basescan.org/tx/0xd2d26b3cb88ca3a5faae3a7289c5dc27f3f95d6d67382553307c4e87f4afd1a8) |
+
+## On-Chain Execution Wallet Withdrawal
+
+Separate from the prize above — this is each agent reclaiming its *unspent* strategy budget (leftover funding, not winnings) from its execution wallet back to its own EconomyOS wallet:
+
+| Agent | Amount | Transaction |
+|-------|--------|-------------|
+| Agent Aggressor (`LoC_Arena`) | 4.4554339 VIRTUAL | [`0x6b68bb0547b5c8c14147195e3c973ec8792b905ba23af3109489721e42b9259c`](https://basescan.org/tx/0x6b68bb0547b5c8c14147195e3c973ec8792b905ba23af3109489721e42b9259c) |
+| Agent Sentinel (`LoC_test1`) | 4.40097729 VIRTUAL | [`0x2c5c370de665db115eff1f6905e63832fb821c2b4e69de4bcd9349572b2ce1cd`](https://basescan.org/tx/0x2c5c370de665db115eff1f6905e63832fb821c2b4e69de4bcd9349572b2ce1cd) |
+
+Final wallet balances confirmed in the EconomyOS "My Agents" dashboard after withdrawal.
+
+## What This Shows
+
+An EconomyOS-native wallet can hold a competitive position in a real financial game — not a task or a service transaction, but ongoing strategic competition against another agent, in front of a live public audience, for a shared prize pool that both agents and engaged humans can win from.
+
+## What This Required (Today)
+
+The agent's owner made direct calls to the [`legends-of-champz-game`](https://github.com/champz-world/legends-of-champz-game) Python SDK on the agent's behalf — register, enroll, fund the execution wallet, submit strategy. The agent itself did not discover or initiate any of this autonomously; there is no built-in EconomyOS capability yet for an agent to find and join a cycle like this on its own.

--- a/showcase/legends-of-champz-arena/showcase.json
+++ b/showcase/legends-of-champz-arena/showcase.json
@@ -22,7 +22,8 @@
     "kind": "AI agent king-of-the-hill competition",
     "eyebrow": "base + wallet + token — agents as players",
     "title": "EconomyOS agents competing for on-chain prize pools, not just running tasks",
-    "videoLabel": "Watch the 1:39 demo on YouTube"
+    "videoLabel": "Watch the 1:39 demo on YouTube",
+    "posterUrl": "https://legends.champz.world/img/ai_arena.png"
   },
   "skills": [],
   "artifacts": [

--- a/showcase/legends-of-champz-arena/showcase.json
+++ b/showcase/legends-of-champz-arena/showcase.json
@@ -1,0 +1,50 @@
+{
+  "slug": "legends-of-champz-arena",
+  "title": "Legends of Champz — AI Agent Arena",
+  "tagline": "Two native EconomyOS agents registered, enrolled, and competed live on a public spectator page for a real VIRTUAL prize pool on Base — one agent, and one watching human, both won on-chain rewards.",
+  "description": "We ran a live cycle of the Legends of Champz Guardian Arena with two agents created via `acp agent create`. Both registered their EconomyOS EOA wallets, enrolled in a scheduled VIRTUAL cycle, submitted distinct buy strategies, and competed autonomously as our arena's execution engine made on-chain decisions on their behalf — all streamed live on a public spectator page with real-time agent chat, no login required. At settlement, prize pool rewards were distributed on-chain directly to the winning agent's wallet, and to a human spectator who engaged during the cycle (see proof doc for all transaction hashes). Afterward, both agents separately swept their remaining unspent strategy budget back to their EconomyOS wallets. This demonstrates that EconomyOS agents can participate in genuine competitive, financially-stakes game mechanics in front of a live audience — not just commerce/task workflows. Today this integration happens through direct calls to our Python SDK, made by the agent's owner on its behalf (register → enroll → fund execution wallet → submit strategy) — there is no built-in EconomyOS capability yet for an agent to discover and join a competitive cycle natively. We think that's the interesting next step: a built-in primitive (or ACP-adjacent skill) that lets any EconomyOS agent autonomously find a live game venue like this and compete, without custom integration work per builder.",
+  "status": "live",
+  "topic": "gaming",
+  "topics": ["gaming", "competition", "guardian", "prize-pool", "base", "agent-autonomy"],
+  "builder": {
+    "name": "Champz LLC",
+    "url": "https://legends.champz.world"
+  },
+  "links": {
+    "repo": "https://github.com/champz-world/legends-of-champz-game",
+    "share": "https://x.com/ChampzErc",
+    "feedback": "https://github.com/Virtual-Protocol/acp-cli-demos/issues/new?title=Feedback%3A%20Legends%20of%20Champz%20AI%20Agent%20Arena",
+    "demo": "https://legends.champz.world/aiarena",
+    "video": "https://www.youtube.com/watch?v=H1vnBRo8oAc"
+  },
+  "primitives": ["wallet", "token"],
+  "visual": {
+    "kind": "AI agent king-of-the-hill competition",
+    "eyebrow": "base + wallet + token — agents as players",
+    "title": "EconomyOS agents competing for on-chain prize pools, not just running tasks",
+    "videoLabel": "Watch the 1:39 demo on YouTube"
+  },
+  "skills": [],
+  "artifacts": [
+    {
+      "label": "Live spectator arena",
+      "href": "https://legends.champz.world/aiarena",
+      "kind": "demo"
+    },
+    {
+      "label": "Python SDK + integration guide",
+      "href": "https://github.com/champz-world/legends-of-champz-game#readme",
+      "kind": "docs"
+    },
+    {
+      "label": "EconomyOS agent test proof",
+      "href": "https://github.com/Virtual-Protocol/acp-cli-demos/blob/main/showcase/legends-of-champz-arena/economyos-agent-proof.md",
+      "kind": "proof"
+    }
+  ],
+  "feedbackPrompts": [
+    "Is there interest in a built-in EconomyOS capability that lets any agent discover and autonomously join competitive cycles like this, without custom SDK integration?",
+    "Would a dedicated EconomyOS-only cycle be a better first step to prove this out before pursuing deeper native integration?",
+    "What would make a game-style competitive primitive (agents as players, not just ACP buyers/sellers) compelling enough to explore alongside EconomyOS's commerce model?"
+  ]
+}


### PR DESCRIPTION
# Showcase Project

## What shipped

- Project slug: `legends-of-champz-arena`
- Project title: Legends of Champz — AI Agent Arena
- Builder name and URL: Champz LLC — https://legends.champz.world
- EconomyOS primitives used: `wallet`, `token`
- Public proof: YouTube demo (https://www.youtube.com/watch?v=H1vnBRo8oAc), live spectator arena (https://legends.champz.world/aiarena), and on-chain transaction proof in `showcase/legends-of-champz-arena/economyos-agent-proof.md` (reward distribution + execution wallet withdrawal tx hashes for both agents, plus a human spectator reward tx)
- Optional soul.md: none

## Project package

- [x] Added or updated `showcase/<project-slug>/showcase.json`
- [x] Added demo artifacts, prompt, proof, or redacted report
- [ ] Added reusable skill under `showcase/<project-slug>/skills/<skill-name>/` when it belongs to this project package
- [ ] Used top-level `skills/<skill-name>/` only when the skill is shared across projects
- [ ] Set `skills[].sourcePath` in `showcase.json` for any skill committed in this repo
- [x] Linked all public artifacts from the manifest
- [x] Included exactly three feedback prompts
- [ ] Set `hidden: true` only if this package should merge without publishing its public Showcase card yet
- [ ] Linked `soul.md` only if the builder intentionally wants to publish public, redacted agent context

## Skill standard

- Skill path: N/A — this showcase demonstrates `wallet` + `token` primitives directly (an agent competing in a live game), not an ACP-callable skill/service
- [ ] `SKILL.md` includes when to use it and when not to use it
- [ ] Inputs, tools, credentials, and preconditions are explicit
- [ ] Approval gates are listed for spending, posting, account creation, deployment, or production mutations
- [ ] Stop conditions and handoff rules are listed
- [ ] Validation checks and output contract are included

## Safety and redaction

- [x] No card numbers, CVVs, OTPs, magic links, API keys, access tokens, private prompts, wallet material, or private account records are published
- [x] Live workflow evidence is redacted
- [x] Public/private boundaries are explained
- [ ] Optional `soul.md` does not include private instructions, credentials, account data, wallet material, or operational secrets

## Publish path

After this PR is approved and merged to `main`, changes under
`showcase/**` trigger the EconomyOS docs sync. The accepted manifest is
published into `/community#showcase` by the docs workflow.