### PR TITLE
docs: complete the showcase contributor guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ After a Showcase PR is approved and merged to `main`, changes under
 regenerates the Showcase page data from the accepted manifest.
 
 Automation requirement: configure `SHOWCASE_SYNC_TOKEN` in this repo with
-permission to dispatch workflows in `Virtual-Protocol/whitepaper-economyOS`.
+permission to dispatch workflows in the EconomyOS docs repo.
 
 Validate manifests before requesting review:
 

--- a/scripts/validate-showcase.mjs
+++ b/scripts/validate-showcase.mjs
@@ -1,5 +1,10 @@
 #!/usr/bin/env node
 
+// Validates showcase manifests against the shape documented in
+// showcase/README.md. MAINTAINERS: if you add, remove, or change a rule here,
+// update the "Field Reference" table and the "Maintainers" section in
+// showcase/README.md in the same PR so the docs stay the source of truth.
+
 import fs from 'node:fs'
 import path from 'node:path'
 import process from 'node:process'

--- a/showcase/README.md
+++ b/showcase/README.md
@@ -5,57 +5,117 @@ Showcase after the contribution PR is approved and merged.
 
 Each public entry lives in `showcase/<project-slug>/`. The manifest is
 `showcase/<project-slug>/showcase.json`, and the same folder can contain the
-proof notes, project-specific skill, artifacts, and reviewer context needed by
-the docs site.
+proof notes, project-specific skill, artifacts, image assets, and reviewer
+context needed by the docs site.
+
+New here? Read [End-To-End Flow](#end-to-end-flow), fill in the
+[Field Reference](#field-reference), then run the
+[Contributor Checklist](#contributor-checklist) before opening your PR.
+Copy [`paid-substack-subscription/showcase.json`](paid-substack-subscription/showcase.json)
+as a starting point.
 
 ## End-To-End Flow
 
 1. Build a real EconomyOS workflow and capture public proof.
-2. Add the project package under `showcase/<project-slug>/`.
+2. Add the project package under `showcase/<project-slug>/`. The folder name
+   **must** match the manifest `slug`.
 3. Add a project-specific reusable skill under
    `showcase/<project-slug>/skills/<skill-name>/` when the workflow can be
    repeated. Use top-level `skills/<skill-name>/` only when the skill is shared
    across projects.
-4. Open a PR against `Virtual-Protocol/acp-cli-demos`.
-5. Reviewers check the demo package, redaction, skill quality, and manifest.
-6. After merge to `main`, the sync workflow publishes the manifest into the
-   EconomyOS docs Showcase data.
+4. Validate locally: `node scripts/validate-showcase.mjs`.
+5. Open a PR against `Virtual-Protocol/acp-cli-demos`.
+6. Reviewers check the demo package, redaction, skill quality, and manifest
+   (see [What Reviewers Check](#what-reviewers-check)).
+7. After merge to `main`, the sync workflow publishes the manifest into the
+   EconomyOS docs Showcase data. Confirm it landed — see
+   [Confirming Your Card Went Live](#confirming-your-card-went-live).
 
 The publish step requires the `SHOWCASE_SYNC_TOKEN` repository secret to be set
 in `acp-cli-demos`. It should be a GitHub token that can create a repository
 dispatch event in `Virtual-Protocol/whitepaper-economyOS`.
 
-## Required Shape
+## Field Reference
 
-Use the Paid Substack example as the reference:
+This table is the source of truth for the manifest shape. Every rule here is
+enforced by [`scripts/validate-showcase.mjs`](../scripts/validate-showcase.mjs);
+run it before requesting review.
 
-- `showcase/paid-substack-subscription/showcase.json`
-- `skills/acp-paid-subscription-checkout/` as a shared skill source for this
-  example
-- `skills/acp-paid-subscription-checkout/examples/substack/`
+| Field | Required | Type | Notes |
+| --- | --- | --- | --- |
+| `slug` | yes | string | Lowercase kebab-case (`^[a-z0-9]+(-[a-z0-9]+)*$`). **Must equal the folder name** `showcase/<slug>/`. **Globally unique** across all manifests. This is the card's identity key — do not rename it later (see [Updating a Published Showcase](#updating-a-published-showcase)). |
+| `title` | yes | string | Display name of the project. |
+| `tagline` | yes | string | One line. See [Copy and Style Conventions](#copy-and-style-conventions). |
+| `description` | yes | string | 2–4 sentences. See [Copy and Style Conventions](#copy-and-style-conventions). |
+| `status` | yes | string | Free text, e.g. `live`, `active`, `validated demo`. |
+| `topic` | yes | string | Single primary category. Current values in use: `agents`, `skills`, `commerce`, `security`. Pick the closest one. |
+| `topics` | yes | string[] | Non-empty list of search/filter tags. Distinct from `topic` — these are the free-form tags; `topic` is the one primary bucket. |
+| `builder.name` | yes | string | |
+| `builder.url` | yes | URL | `http(s)://` |
+| `links.repo` | yes | URL | Source or package location. |
+| `links.share` | yes | URL | The post/page to share. |
+| `links.feedback` | yes | URL | Where feedback goes (issue link is fine). |
+| `links.demo` | no | URL | Optional live demo / proof link. |
+| `links.video` | no | URL | Public watch page. Setting this makes `visual.videoLabel` required. See [Video Fields](#video-fields). |
+| `primitives` | yes | string[] | Non-empty. Allowed: `wallet`, `email`, `card`, `token`, `acp`. |
+| `visual.kind` | yes | string | Short descriptor of the card kind. |
+| `visual.eyebrow` | yes | string | Small label above the title on the card. |
+| `visual.title` | yes | string | Card headline. |
+| `visual.posterUrl` | no | URL | Card hero image. See [Card Image](#card-image). |
+| `visual.videoUrl` | no | URL | Direct video **file** only. See [Video Fields](#video-fields). |
+| `visual.videoLabel` | conditional | string | Required when `links.video` is set; must name the platform. |
+| `skills` | yes | object[] | Array (may be empty if there is no reusable skill). Each entry needs `name`, `href` (URL), `summary`, `install`. |
+| `skills[].sourcePath` | no | relative path | When the skill is committed in this repo. Must stay inside the repo and contain a `SKILL.md`. |
+| `artifacts` | yes | object[] | **Non-empty.** Each entry needs `label`, `href` (URL), `kind`. Include at least one inspectable proof. |
+| `soul` | no | object | When publishing public agent context: `soul.href` (URL) + `soul.summary`. See [Optional Agent Context](#optional-agent-context). |
+| `feedbackPrompts` | yes | string[] | **Exactly three** non-empty prompts. |
+| `hidden` | no | boolean | `true` keeps the package valid but stops the docs sync from publishing the card. See [Visibility Control](#visibility-control). |
 
-Note: that reference manifest uses a site-relative `visual.posterUrl`, which is
-a maintainer-managed asset in the docs repo. Contributor PRs must use an
-`https://` poster URL instead — see [Video Fields](#video-fields).
+Proof matters more than polish. An X video is highly recommended when possible
+because it is visual and easy to share, but it is not required. Use any
+inspectable artifact that shows the project or workflow ran: screenshot, hosted
+video, animated demo, live page, interactive demo, public PR, demo repo, or
+redacted result report.
 
-Every manifest needs:
+## Copy and Style Conventions
 
-- `slug`, `title`, `tagline`, `description`, `status`, `topic`, and `topics`
-- `builder.name` and `builder.url`
-- `links.repo`, `links.share`, and `links.feedback`
-- `primitives`, using `wallet`, `email`, `card`, `token`, or `acp`
-- `visual.kind`, `visual.eyebrow`, and `visual.title`
-- `skills`, when the workflow is reusable; each entry needs `name`, `href`,
-  `summary`, and `install`
-- `skills[].sourcePath`, when the skill is committed in this repo and should be
-  validated against a local `SKILL.md`
-- `artifacts`, including proof and redacted reports for live workflows
-- exactly three `feedbackPrompts`
+Keep card copy consistent with the projects already published:
 
-An X video is highly recommended when possible because it is visual and easy to
-share, but it is not required. Use any inspectable artifact that shows the
-project or workflow ran: screenshot, hosted video, animated demo, live page,
-interactive demo, public PR, demo repo, or redacted result report.
+- **Tagline** — lead with a verb / the offering, present tense, describe what
+  the agent *does*. No "An X agent that…" preamble, and **no trailing period**.
+  - Good: `Audits a public GitHub PR with two frontier models and reports only the findings both agree on, with SHA-pinned receipts`
+  - Good: `Scans an ACP agent contract and returns a Trust Score grading six security dimensions from A to F`
+  - Avoid: `An autonomous agent that runs reviews…` (buries the offering behind a preamble and reads like a meta-description).
+- **Description** — 2–4 sentences. Say what it does, then what proof backs it
+  (receipts, deliverable shape, on-chain identity). Plain language, no marketing
+  filler.
+- **`topic` vs `topics`** — `topic` is the single primary bucket used for
+  grouping; `topics` are the free-form tags used for search. Don't duplicate the
+  title in either.
+
+## Card Image
+
+`visual.posterUrl` is the card's hero image. It works **with or without a
+video** — a poster set on a project that has no video renders as a static card
+image, so this is how a no-video project gets a picture on its card.
+
+- Must be an `https://` image URL. (Site-relative `/...` paths are
+  maintainer-managed assets in the docs repo — **do not use them in contributor
+  PRs**.)
+- To ship the image inside this repo, commit it as
+  `showcase/<slug>/assets/poster.jpg` and reference
+  `https://raw.githubusercontent.com/Virtual-Protocol/acp-cli-demos/main/showcase/<slug>/assets/poster.jpg`.
+  The `main` URL only resolves **after** the PR merges, so verify the same path
+  on your fork or branch before requesting review.
+- Use a **16:9** image sized for a card hero (e.g. 1280×720 or larger). Other
+  aspect ratios get cropped; 4:3 thumbnails (like YouTube `hqdefault.jpg`) are
+  visibly cut off.
+- Verify it resolves: `curl -sI "<visual.posterUrl>"` should return `200` with
+  an `image/...` content type.
+
+If your project has a video, the poster is sourced from the video platform —
+see [Video Fields](#video-fields) for the per-platform poster URLs (YouTube
+thumbnail, X `amplify_video_thumb`, and so on).
 
 ## Video Fields
 
@@ -70,7 +130,7 @@ every other video page out to its own platform.
 | YouTube | the watch or Shorts URL | omit — the docs site embeds the YouTube player from `links.video` | `https://img.youtube.com/vi/<video-id>/maxresdefault.jpg` | `Watch the 1:50 demo on YouTube` |
 | Vimeo, TikTok, Loom, or another video page | the page URL | omit — page URLs cannot play inline, and tokenized CDN file URLs extracted from players expire | commit a captured frame under `showcase/<slug>/assets/` | `Watch the 1:50 demo on Vimeo` |
 | Self-hosted file | a public page when one exists, otherwise the file URL | the direct `.mp4` file URL (see hosting notes below) | recommended | `Watch the 1:50 demo` |
-| No video | omit | omit | optional — prefer adding screenshots under `artifacts`; a poster without a video renders as a static image | omit |
+| No video | omit | omit | optional — see [Card Image](#card-image); a poster without a video renders as a static image | omit |
 
 Replace `1:50` with the real video duration.
 
@@ -90,21 +150,15 @@ Field meanings and what the validator enforces:
   its `raw.githubusercontent.com` URL. For Dropbox, use a
   `dl.dropboxusercontent.com` URL. Do not use tokenized CDN URLs pulled out
   of Vimeo or similar players; they expire and silently break the card.
-- `visual.posterUrl` must be an `https://` image URL. It is recommended for
-  every video and required for none. For YouTube, use the thumbnail
+- `visual.posterUrl` for a video follows the [Card Image](#card-image) rules
+  plus these per-platform sources. For YouTube, use the thumbnail
   `https://img.youtube.com/vi/<video-id>/maxresdefault.jpg`; the `<video-id>`
   is the `v=` query parameter on watch URLs or the last path segment of
   `youtube.com/shorts/<id>` and `youtu.be/<id>` links. If `maxresdefault.jpg`
   returns 404, use `sddefault.jpg`; `hqdefault.jpg` is 4:3 and gets visibly
   cropped on the 16:9 card. For X videos, copy the
   `https://pbs.twimg.com/amplify_video_thumb/...` image URL from the same
-  devtools capture as the video file. To ship a poster inside this repo,
-  commit it as `showcase/<slug>/assets/poster.jpg` and reference
-  `https://raw.githubusercontent.com/Virtual-Protocol/acp-cli-demos/main/showcase/<slug>/assets/poster.jpg`;
-  the `main` URL resolves only after the PR merges, so verify the same path
-  on your fork or branch instead. Site-relative paths such as
-  `/showcase/<slug>-poster.jpg` are maintainer-managed assets in the docs
-  repo; do not use them in contributor PRs.
+  devtools capture as the video file.
 - `visual.videoLabel` is required whenever `links.video` is set. It is the
   watch-button text for featured builds and the accessible label on the
   card's play link, so it must name the platform the viewer lands on. The
@@ -115,7 +169,66 @@ To get the direct file URL from an X post: open the post in a browser, open
 developer tools, filter network requests by `video.twimg.com`, play the video,
 and copy the highest-resolution `.mp4` request URL.
 
-Verify before requesting review (humans and AI agents):
+## Visibility Control
+
+- `hidden: true` keeps the package valid in this repo but prevents the EconomyOS
+  docs sync from publishing the card. Remove it in a later PR when the showcase
+  should go live.
+
+## Optional Agent Context
+
+- `soul.md` can be included when the builder intentionally wants to publish
+  public agent context. Prefer committing the text as
+  `showcase/<project-slug>/soul.md`; use a `soul/` folder only for multi-agent
+  or multi-file context. Redact private instructions, credentials, account data,
+  wallet material, and operational secrets before linking it from
+  `showcase.json` as `soul.href` with a short `soul.summary`.
+
+## Updating a Published Showcase
+
+Editing a project that is already merged and published is the **same flow** as
+adding one — there is no separate update path. The sync regenerates the whole
+docs dataset from the source manifests, so your edit overwrites the old
+published values automatically. Never hand-edit the generated file in the docs
+repo.
+
+1. Branch off `main`, edit the files under `showcase/<slug>/` in place
+   (manifest, `README.md`, `soul.md`, skill, or `assets/`).
+2. `node scripts/validate-showcase.mjs`.
+3. Open a PR, merge, then confirm the sync ran (below).
+
+**Do not change `slug`.** It is the card's identity key. Editing any other
+field updates the existing card; changing the slug (and its folder) reads as a
+brand-new project and orphans the old card. Rename only when you truly intend a
+new entry.
+
+## Confirming Your Card Went Live
+
+Publishing is not automatic-and-silent — it depends on the sync workflow
+actually running. After your PR merges to `main`:
+
+1. In `acp-cli-demos` → **Actions**, confirm the **Dispatch Showcase Sync** run
+   on your merge commit is green. A red run (usually a missing or expired
+   `SHOWCASE_SYNC_TOKEN`) means the card will **not** appear.
+2. The regenerated card data lands in `Virtual-Protocol/whitepaper-economyOS`.
+   Check the Showcase page there once its docs build completes.
+
+You cannot preview the rendered card before merge, so validate, confirm every
+URL returns `200`, and double-check copy against
+[Copy and Style Conventions](#copy-and-style-conventions) beforehand.
+
+## Contributor Checklist
+
+Before requesting review:
+
+- [ ] Folder name equals `slug`, and `slug` is lowercase kebab-case and unique.
+- [ ] All required [Field Reference](#field-reference) fields are present.
+- [ ] `feedbackPrompts` has exactly three entries; `artifacts` has at least one.
+- [ ] At least one inspectable proof artifact is included and redacted.
+- [ ] Tagline/description follow [Copy and Style Conventions](#copy-and-style-conventions).
+- [ ] Any `posterUrl` / `videoUrl` / image URL returns `200` (checked on your
+      branch, since `main` raw URLs only resolve after merge).
+- [ ] `node scripts/validate-showcase.mjs` passes.
 
 ```bash
 # Expect HTTP 200 and content-type: video/...
@@ -131,23 +244,36 @@ curl -sI "<visual.posterUrl>"
 node scripts/validate-showcase.mjs
 ```
 
-Optional visibility control:
+## What Reviewers Check
 
-- `hidden: true` keeps the package valid in this repo but prevents the EconomyOS
-  docs sync from publishing the card. Remove it in a later PR when the showcase
-  should go live.
+- **Manifest** — passes the validator; slug/folder match; copy follows the
+  conventions above.
+- **Proof** — at least one artifact is inspectable and actually shows the
+  workflow ran.
+- **Redaction** — no credentials, private keys, wallet material, account data,
+  or private instructions in the package, `soul.md`, or proof docs.
+- **Skill quality** — any committed `SKILL.md` is clear, scoped, and reusable.
+- **Media** — video/image URLs resolve and follow the field rules.
 
-Optional agent context:
+## Maintainers
 
-- `soul.md` can be included when the builder intentionally wants to publish
-  public agent context. Prefer committing the text as
-  `showcase/<project-slug>/soul.md`; use a `soul/` folder only for multi-agent
-  or multi-file context. Redact private instructions, credentials, account data,
-  wallet material, and operational secrets before linking it from
-  `showcase.json` as `soul.href` with a short `soul.summary`.
+The manifest schema is enforced by
+[`scripts/validate-showcase.mjs`](../scripts/validate-showcase.mjs), and the
+publish is driven by
+[`.github/workflows/dispatch-showcase-sync.yml`](../.github/workflows/dispatch-showcase-sync.yml)
+(which dispatches to `sync-showcase-projects.mjs` in
+`Virtual-Protocol/whitepaper-economyOS`).
 
-Run this before requesting review:
+**If you change any of these, update this doc in the same PR so it stays the
+source of truth:**
 
-```bash
-node scripts/validate-showcase.mjs
-```
+- Add/remove/rename a manifest field or change a validation rule in
+  `validate-showcase.mjs` → update the [Field Reference](#field-reference) table
+  and any affected section.
+- Change the set of allowed `primitives`, `topic` values, or accepted video
+  hosts → update the relevant rows/notes.
+- Change how the sync is triggered or which repo/token it uses → update
+  [End-To-End Flow](#end-to-end-flow) and
+  [Confirming Your Card Went Live](#confirming-your-card-went-live).
+- Change how the docs site renders the card (hero image, video, aspect ratio)
+  → update [Card Image](#card-image) and [Video Fields](#video-fields).

--- a/showcase/README.md
+++ b/showcase/README.md
@@ -33,7 +33,7 @@ as a starting point.
 
 The publish step requires the `SHOWCASE_SYNC_TOKEN` repository secret to be set
 in `acp-cli-demos`. It should be a GitHub token that can create a repository
-dispatch event in `Virtual-Protocol/whitepaper-economyOS`.
+dispatch event in the EconomyOS docs repo.
 
 ## Field Reference
 
@@ -210,8 +210,8 @@ actually running. After your PR merges to `main`:
 1. In `acp-cli-demos` → **Actions**, confirm the **Dispatch Showcase Sync** run
    on your merge commit is green. A red run (usually a missing or expired
    `SHOWCASE_SYNC_TOKEN`) means the card will **not** appear.
-2. The regenerated card data lands in `Virtual-Protocol/whitepaper-economyOS`.
-   Check the Showcase page there once its docs build completes.
+2. The regenerated card data lands in the EconomyOS docs repo. Check the
+   Showcase page once its docs build completes.
 
 You cannot preview the rendered card before merge, so validate, confirm every
 URL returns `200`, and double-check copy against
@@ -261,8 +261,8 @@ The manifest schema is enforced by
 [`scripts/validate-showcase.mjs`](../scripts/validate-showcase.mjs), and the
 publish is driven by
 [`.github/workflows/dispatch-showcase-sync.yml`](../.github/workflows/dispatch-showcase-sync.yml)
-(which dispatches to `sync-showcase-projects.mjs` in
-`Virtual-Protocol/whitepaper-economyOS`).
+(which dispatches a repository event to the EconomyOS docs repo, where a sync
+script regenerates the Showcase dataset).
 
 **If you change any of these, update this doc in the same PR so it stays the
 source of truth:**


### PR DESCRIPTION
## Summary

Completes the Showcase contributor guide so builders can self-serve, and
removes the private docs-repo name from public files. Docs and comments only —
no manifest, schema, or workflow behavior changes.

Files touched: `showcase/README.md`, `README.md`, `scripts/validate-showcase.mjs`.

## Why

The guide only covered a first-time submission and scattered the manifest rules
across prose, so contributors hit validator failures with no matching docs and
had no guidance for editing a published card, adding a card image, or writing
consistent copy. Separately, this repo is public while the EconomyOS docs repo
is private, and its path was exposed in the READMEs.

## What changed

**`showcase/README.md` — new/expanded sections**
- **Field Reference table** — single source of truth for every manifest field,
  making explicit the rules the validator enforces but the guide never stated:
  folder name must equal `slug`, `slug` is lowercase kebab-case and globally
  unique, `artifacts` is non-empty, `topic` vs `topics`, `sourcePath` must
  contain a `SKILL.md`, exactly three `feedbackPrompts`.
- **Card Image** — dedicated `visual.posterUrl` hero-image guidance (with or
  without a video, 16:9 sizing); Video Fields now links here instead of
  duplicating the poster mechanics.
- **Copy and Style Conventions** — tagline leads with the offering, no trailing
  period; description length; `topic` vs `topics`.
- **Updating a Published Showcase** — edit-in-place flow + "don't rename `slug`,
  it's the card's identity key."
- **Confirming Your Card Went Live** — check the Dispatch Showcase Sync run is
  green (a missing `SHOWCASE_SYNC_TOKEN` means the card never appears).
- **Contributor Checklist** and **What Reviewers Check**.
- **Maintainers** — if the schema, validator, or sync changes, update this doc
  in the same PR.

**`scripts/validate-showcase.mjs`**
- Added a header comment pointing maintainers back to the guide when they change
  a validation rule (no logic change).

**`README.md` + `showcase/README.md`**
- Genericized references to the private EconomyOS docs repo to "the EconomyOS
  docs repo" so the private path is not exposed in the public tree.

## Testing

- `node scripts/validate-showcase.mjs` -> passes (7 manifests).
- All in-page anchor links in `showcase/README.md` resolve.

## Note

`.github/workflows/dispatch-showcase-sync.yml` still names the target repository
(required by the `repository-dispatch` action); left as-is in this PR.
