### PR TITLE
Monvera - an accountable AI broker for real tokenized stocks

### DIFF
--- a/showcase/monvera/README.md
+++ b/showcase/monvera/README.md
@@ -1,0 +1,46 @@
+# Monvera - an accountable AI broker
+
+An AI broker for real tokenized stocks and funds on Robinhood Chain. You tell Vera, its
+AI agent, a goal in plain words; she builds a diversified basket of real companies (Apple,
+Nvidia, the S&P 500, US Treasuries), each with a one-line reason and a plain read on the
+risk, and invests it in one tap. Gasless, non-custodial, from one dollar.
+
+Live at [monvera.best](https://monvera.best) · Docs at [docs.monvera.best](https://docs.monvera.best)
+
+## What Virtuals / EconomyOS made possible
+
+- **Agent Card** - Vera's ERC-8004 identity (agent `58228` on Base), registered **via Virtuals ACP**. Live at [`/.well-known/agent-card.json`](https://monvera.best/.well-known/agent-card.json).
+- **Agent Wallet + ACP** - the registration runs through Vera's ACP wallet. ACP registration file: [api.acp.virtuals.io/agents/019f2d81.../erc8004](https://api.acp.virtuals.io/agents/019f2d81-921d-7951-a4f7-50f9d228c47b/erc8004).
+- **Inference** - Virtuals-hosted inference builds every plan Vera proposes.
+
+## Why it belongs in the Showcase
+
+Most "AI investing" is a black box. Monvera makes the AI accountable: a verifiable agent
+identity plus a signed, on-chain, uneditable record of every recommendation. Vera signs
+each plan's risk assessment with her own key, and that signature is verified and recorded
+on-chain in the **same transaction** that buys the stocks, so her track record cannot be
+edited afterward. Every trust claim resolves to something a skeptic can open.
+
+## Proof
+
+- **Promo video (1:00):** https://x.com/monvera_best/status/2074487457505268213
+- **Live agent card (identity):** https://monvera.best/.well-known/agent-card.json
+- **A signed plan recorded on-chain:** https://robinhoodchain.blockscout.com/tx/0x7ad119f916e1f6daff7d54429ea35ffe81c988730c534b176dcc2f9660cf45d6
+- **Redacted result report:** [`examples/result-redacted.md`](examples/result-redacted.md)
+- **Reproducible verification recipe:** https://docs.monvera.best/dev/verify-vera/
+
+## Reusable skill
+
+[`skills/accountable-onchain-agent`](skills/accountable-onchain-agent/SKILL.md) - the pattern
+behind Monvera, generalized: give an AI agent an ERC-8004 identity, EIP-712 sign a structured
+assessment of each output, and record the signature on-chain in the same transaction as the
+action, so anyone can recover the signer and confirm it. See also [`soul.md`](soul.md) for
+Vera's public context.
+
+## Primitives
+
+Agent Card and Agent Wallet, both via Virtuals ACP.
+
+## Builder
+
+[@Magicianafk](https://x.com/Magicianafk) · [github.com/Magicianhax/monvera](https://github.com/Magicianhax/monvera) · [@monvera_best](https://x.com/monvera_best)

--- a/showcase/monvera/examples/result-redacted.md
+++ b/showcase/monvera/examples/result-redacted.md
@@ -1,0 +1,36 @@
+# Redacted result: an accountable plan, recorded and verified on-chain
+
+This report shows one real run of Monvera's accountable-AI flow on Robinhood Chain (chain
+4663). Every value below is already public, either on-chain or on a public HTTP endpoint. No
+secrets are included.
+
+## The run
+
+1. A user gave Vera a goal and an amount.
+2. Vera built a diversified plan of real tokenized stocks and signed a `RiskInference`
+   assessment of it with her own agent key.
+3. In one transaction, the `VeraRecord` contract verified her signature and recorded the
+   plan, and the trades settled.
+
+## The record (public)
+
+- Chain: Robinhood Chain, id `4663` (explorer: https://robinhoodchain.blockscout.com)
+- VeraRecord contract: `0x7ff1a5ee19330c165146488a7ad8af6cb41da1df`
+- Plan id: `0xbef518779bc7cae74e60da8e111bc7c17423b70a721b7aaa2498893a138122a7`
+- Record transaction: https://robinhoodchain.blockscout.com/tx/0x7ad119f916e1f6daff7d54429ea35ffe81c988730c534b176dcc2f9660cf45d6
+
+## Verify it yourself
+
+1. Read Vera's agent card: https://monvera.best/.well-known/agent-card.json (note
+   `agentSigner`, `identityRegistry`, and `agentId`).
+2. Read `agentSigner()` live on the VeraRecord contract.
+3. Pull the `RecommendationCommitted` log for the plan id above on Blockscout.
+4. Recover the EIP-712 signer of the `RiskInference` payload and assert it equals
+   `agentSigner()`.
+
+Full recipe: https://docs.monvera.best/dev/verify-vera/
+
+## Redaction
+
+No private keys, user account data, session-signer secrets, or provider API keys are
+included. Every value above is already public on-chain or on a public HTTP endpoint.

--- a/showcase/monvera/showcase.json
+++ b/showcase/monvera/showcase.json
@@ -1,0 +1,105 @@
+{
+  "slug": "monvera",
+  "title": "Monvera - an accountable AI broker",
+  "tagline": "Turns a plain-language goal into a diversified basket of real tokenized stocks and records a signed, verifiable risk assessment on-chain in the same transaction that invests it",
+  "description": "Monvera is an AI broker for real tokenized stocks and funds on Robinhood Chain. You tell Vera a goal in plain words and she builds a diversified basket of real companies, each with a reason and a plain read on the risk, then invests it in one tap: gasless, non-custodial, from one dollar. Vera is a verifiable on-chain agent whose ERC-8004 identity is registered via Virtuals ACP, and she signs each plan's risk assessment with her own key. That signature is verified and recorded on-chain in the same transaction that buys the stocks, so anyone can read her agent card, recover the signer of a recorded plan, and confirm it against her identity.",
+  "status": "live",
+  "topic": "agents",
+  "topics": ["finance", "investing", "tokenized-stocks", "identity", "accountability", "erc-8004"],
+  "hidden": false,
+  "builder": {
+    "name": "Magicianafk",
+    "url": "https://x.com/Magicianafk"
+  },
+  "links": {
+    "repo": "https://github.com/Magicianhax/monvera",
+    "demo": "https://monvera.best/demo",
+    "video": "https://x.com/monvera_best/status/2074487457505268213",
+    "share": "https://x.com/monvera_best/status/2074487457505268213",
+    "feedback": "https://github.com/Magicianhax/monvera/issues"
+  },
+  "primitives": ["card", "wallet"],
+  "visual": {
+    "kind": "x demo video",
+    "eyebrow": "ai broker - robinhood chain",
+    "title": "meet vera",
+    "videoUrl": "https://assets.monvera.best/promo/monvera-1min.mp4",
+    "posterUrl": "https://monvera.best/opengraph-image.png",
+    "videoLabel": "Watch the 1:00 demo on X"
+  },
+  "skills": [
+    {
+      "name": "accountable-onchain-agent",
+      "href": "https://github.com/Virtual-Protocol/acp-cli-demos/tree/main/showcase/monvera/skills/accountable-onchain-agent",
+      "sourcePath": "showcase/monvera/skills/accountable-onchain-agent",
+      "summary": "Make an AI agent's outputs verifiable: give it an ERC-8004 identity, EIP-712 sign a structured assessment of each output, and record the signature on-chain in the same transaction as the action, so anyone can recover the signer and confirm it against the agent's identity.",
+      "install": "cp -R showcase/monvera/skills/accountable-onchain-agent ~/.agents/skills/"
+    }
+  ],
+  "artifacts": [
+    {
+      "label": "Live app",
+      "href": "https://monvera.best",
+      "kind": "live"
+    },
+    {
+      "label": "Docs",
+      "href": "https://docs.monvera.best",
+      "kind": "docs"
+    },
+    {
+      "label": "Vera's public agent page",
+      "href": "https://monvera.best/agent",
+      "kind": "live"
+    },
+    {
+      "label": "Vera's agent card (ERC-8004, via Virtuals ACP)",
+      "href": "https://monvera.best/.well-known/agent-card.json",
+      "kind": "proof"
+    },
+    {
+      "label": "ACP registration file",
+      "href": "https://api.acp.virtuals.io/agents/019f2d81-921d-7951-a4f7-50f9d228c47b/erc8004",
+      "kind": "proof"
+    },
+    {
+      "label": "A signed plan recorded on-chain (Blockscout)",
+      "href": "https://robinhoodchain.blockscout.com/tx/0x7ad119f916e1f6daff7d54429ea35ffe81c988730c534b176dcc2f9660cf45d6",
+      "kind": "proof"
+    },
+    {
+      "label": "Redacted result report (accountable run)",
+      "href": "https://github.com/Virtual-Protocol/acp-cli-demos/blob/main/showcase/monvera/examples/result-redacted.md",
+      "kind": "proof"
+    },
+    {
+      "label": "Open strategies with walk-forward backtests",
+      "href": "https://monvera.best/api/strategies",
+      "kind": "proof"
+    },
+    {
+      "label": "Verify Vera yourself (docs)",
+      "href": "https://docs.monvera.best/dev/verify-vera/",
+      "kind": "doc"
+    },
+    {
+      "label": "Reusable skill: accountable-onchain-agent",
+      "href": "https://github.com/Virtual-Protocol/acp-cli-demos/tree/main/showcase/monvera/skills/accountable-onchain-agent",
+      "kind": "skill"
+    },
+    {
+      "label": "Promo video",
+      "href": "https://x.com/monvera_best/status/2074487457505268213",
+      "kind": "video"
+    }
+  ],
+  "soul": {
+    "href": "https://github.com/Virtual-Protocol/acp-cli-demos/blob/main/showcase/monvera/soul.md",
+    "summary": "Public context for Vera: her role building diversified baskets of real tokenized stocks, what she is allowed to do, her boundaries (non-custodial, signs assessments not spends, an on-chain risk ceiling), and how to verify her."
+  },
+  "feedbackPrompts": [
+    "Which other agent outputs are worth recording on-chain for accountability?",
+    "What would make a verifiable agent identity easier to adopt for other builders?",
+    "Which markets or asset types should Vera support next?"
+  ]
+}

--- a/showcase/monvera/skills/accountable-onchain-agent/SKILL.md
+++ b/showcase/monvera/skills/accountable-onchain-agent/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: accountable-onchain-agent
+description: Make an AI agent's outputs verifiable and tamper-evident by giving the agent an on-chain identity, having it EIP-712 sign a structured assessment of each output, and recording that signature on-chain in the same transaction as the action it justifies. Use when a skeptic should be able to confirm the agent authored a specific output and that the record cannot be edited afterward.
+---
+
+# Accountable On-Chain Agent
+
+## Overview
+
+This skill turns an AI agent's outputs into a verifiable, uneditable on-chain record. The
+agent gets a verifiable identity (an ERC-8004 registration, for example via Virtuals ACP),
+signs a structured claim about each output with its own key (EIP-712), and that signature is
+verified and written on-chain in the same transaction as the action it justifies. Anyone can
+later read the agent's identity, recover the signer of a recorded claim, and confirm they
+match. It proves authorship and integrity, not correctness.
+
+Monvera runs this pattern in production: Vera (agent #1) signs a `RiskInference` assessment of
+each investment plan, and the signature is verified and recorded by the `VeraRecord` contract
+in the same transaction that buys the stocks.
+
+## When to use
+
+- You want an agent's recommendations, decisions, or assessments to be independently verifiable.
+- You need a tamper-evident track record: "the agent said X at time T, and it cannot be edited."
+- The agent's action already touches a chain (a trade, a payment, a mint), so recording is cheap to batch.
+
+## When not to use
+
+- The output needs no third-party verification (internal-only tooling).
+- There is no on-chain action to batch the record with, and a standalone write is not worth it.
+- You need to prove the recommendation is correct or profitable. This proves authorship and integrity, not outcome.
+
+## Required inputs, tools, credentials, preconditions
+
+- An agent signing key, kept server-side and never exposed. Its address is the agent's `agentSigner`.
+- An ERC-8004 identity for the agent (an Identity Registry entry; Virtuals ACP can register one). Note the `agentId` and registry address.
+- A verify-and-record contract on your target chain that recovers the EIP-712 signer, checks it equals the trusted `agentSigner`, enforces bounds, stores the record, and reverts if any check fails. Monvera's is `VeraRecord`.
+- A minimal, meaningful EIP-712 typed struct to sign (the claim schema).
+- An account-abstraction / batching path (for example ERC-4337) so the record and the action land in one transaction.
+
+## Step-by-step workflow
+
+1. Define the claim. Choose the smallest struct that captures the agent's assessment. Monvera uses `RiskInference(bytes32 planId, uint16 assessedRisk, uint16 maxRisk, uint256 expiry)`.
+2. Register the agent identity. Register the agent in an ERC-8004 Identity Registry (via Virtuals ACP or directly). Record `agentId` and the registry address, and publish an agent card at `/.well-known/agent-card.json`.
+3. Sign server-side. When the agent produces an output, EIP-712-sign the claim with the agent signing key under a fixed domain `{name, version, chainId, verifyingContract}`.
+4. Verify and record on-chain, atomically. In the same transaction as the action, call the verify-and-record contract with the claim plus signature. It recovers the signer, asserts `recovered == agentSigner`, enforces bounds (for example `assessedRisk <= maxRisk`) and expiry, then stores the record. If any check fails, the whole transaction reverts, so an action can never be recorded with an invalid or unauthorized claim.
+5. Expose a read path. Provide an endpoint or a docs recipe so anyone can fetch a recorded claim, recover its signer, and compare it to `agentSigner()` and the agent's identity.
+
+## Approval gates
+
+- The user, not the agent, signs the value-moving step (the trade or payment). The agent's signature only attests to its own assessment. Keep the two signatures separate and never conflate them.
+- Bounds are enforced on-chain (for example a risk ceiling the agent cannot exceed), not only in the UI.
+
+## Stop conditions
+
+- Stop if the recovered signer does not equal the expected `agentSigner` (the record would be rejected on-chain anyway).
+- Stop if the claim is expired or exceeds its declared bounds.
+- Stop if the identity registration cannot be confirmed on-chain.
+
+## Evidence and redaction rules
+
+- Evidence to keep (all public): the agent card URL, the on-chain record transaction (explorer link), the signed struct plus recovered signer, and the identity registry entry.
+- Redact: the agent signing key, any user private keys, session-signer secrets, and provider API keys. Never include them in code, logs, or reports.
+
+## Validation checklist
+
+- [ ] The agent card resolves and lists the identity registry and `agentSigner`.
+- [ ] A recorded claim's recovered signer equals `agentSigner()` read live on-chain.
+- [ ] The verify-and-record contract reverts on a bad signer, an out-of-bounds claim, and an expired claim.
+- [ ] The record and the action share one transaction (atomic).
+- [ ] No secrets appear anywhere in the package.
+
+## Output contract
+
+- On-chain: one record event per output (for example `RecommendationCommitted(planId, user, recHash, riskScore, agentId)`), emitted in the same transaction as the action.
+- Off-chain: a read endpoint returning the recorded claim, its signature, the recovered signer, the `agentId`, and the identity registry, so a third party can reproduce the check.
+
+## Worked example (Monvera)
+
+- Identity: Vera is agent #1 in Monvera's Identity Registry `0x751ae640cfa816404b017fbb8234dd21abafbbdc` (chain 4663), canonical ERC-8004 identity `8453:58228` on Base via Virtuals ACP. Agent card: https://monvera.best/.well-known/agent-card.json
+- Contract: `VeraRecord` at `0x7ff1a5ee19330c165146488a7ad8af6cb41da1df`, EIP-712 domain `{ name: "VeraRecord", version: "1", chainId: 4663 }`.
+- A recorded plan on Blockscout: https://robinhoodchain.blockscout.com/tx/0x7ad119f916e1f6daff7d54429ea35ffe81c988730c534b176dcc2f9660cf45d6
+- Reproducible verification recipe: https://docs.monvera.best/dev/verify-vera/

--- a/showcase/monvera/soul.md
+++ b/showcase/monvera/soul.md
@@ -1,0 +1,30 @@
+# Vera - public agent context
+
+Public context for how Vera works and what she is allowed to do. It contains no secrets.
+
+## Role
+
+Vera is Monvera's investing agent. She turns a person's plain-language goal and an amount
+into a diversified basket of real tokenized stocks and funds, each with a one-line reason and
+a plain read on the risk. She is agent #1 in Monvera's ERC-8004 Identity Registry, and her
+canonical identity is registered on Base via Virtuals ACP.
+
+## What she is allowed to do
+
+- Recommend allocations only from a fixed universe of ~95 real tokenized stocks and funds that are quotable and settle in USDG.
+- Sign a risk assessment (EIP-712 `RiskInference`) for every plan she proposes, with her own key.
+- Stay within an on-chain risk ceiling the user sets, which is enforced by contract, not by prompt.
+
+## Boundaries
+
+- She never moves money. The user signs the spend; Vera only signs the assessment.
+- She does not custody funds. Accounts are non-custodial.
+- She does not promise returns. Her signature proves authorship, not correctness.
+- She is honest about risk inline, and about what is enforced on-chain versus not.
+- She never exposes or requests private keys, seed phrases, or secrets.
+
+## How to verify her
+
+Read her agent card at https://monvera.best/.well-known/agent-card.json, pull a recorded plan,
+recover the EIP-712 signer, and confirm it equals her on-chain `agentSigner`. Full recipe:
+https://docs.monvera.best/dev/verify-vera/


### PR DESCRIPTION
# Monvera - an accountable AI broker

[![Watch the 1-minute Monvera demo](https://monvera.best/opengraph-image.png)](https://x.com/monvera_best/status/2074487457505268213)

Monvera is an AI broker for real tokenized stocks on Robinhood Chain. You tell **Vera** a goal in plain words; she builds a diversified basket of real companies, signs her risk assessment, and records it on-chain in the same transaction that invests it. Gasless, non-custodial, from one dollar.

What makes it different is **accountable AI**: a verifiable agent identity plus a signed, on-chain, uneditable record of every recommendation. Every claim below resolves to something you can open.

## What shipped

- **Slug:** `monvera` · **Builder:** [@Magicianafk](https://x.com/Magicianafk)
- **EconomyOS primitives:** Agent Card and Agent Wallet, both via **Virtuals ACP** - Vera's ERC-8004 identity is agent `8453:58228` on Base ([ACP registration file](https://api.acp.virtuals.io/agents/019f2d81-921d-7951-a4f7-50f9d228c47b/erc8004))
- **Live surfaces:** [monvera.best](https://monvera.best) · [docs](https://docs.monvera.best) · [interactive demo](https://monvera.best/demo)

## Proof you can open

- [1-minute promo video](https://x.com/monvera_best/status/2074487457505268213) - plays inline on the card from a [self-hosted mp4](https://assets.monvera.best/promo/monvera-1min.mp4)
- [Vera's live agent card](https://monvera.best/.well-known/agent-card.json) (ERC-8004, via Virtuals ACP)
- [A signed plan recorded on-chain](https://robinhoodchain.blockscout.com/tx/0x7ad119f916e1f6daff7d54429ea35ffe81c988730c534b176dcc2f9660cf45d6) on Blockscout
- [Verify Vera yourself](https://docs.monvera.best/dev/verify-vera/) - read the agent card, recover the signer of a recorded plan, and assert it equals `agentSigner()`
- [Redacted result report](https://github.com/Virtual-Protocol/acp-cli-demos/blob/main/showcase/monvera/examples/result-redacted.md) of one real accountable run

## Reusable skill

[`accountable-onchain-agent`](https://github.com/Virtual-Protocol/acp-cli-demos/tree/main/showcase/monvera/skills/accountable-onchain-agent) - the Monvera pattern, generalized: give an AI agent an ERC-8004 identity, have it EIP-712 sign a structured assessment of each output, and record that signature on-chain in the same transaction as the action, so anyone can recover the signer and confirm it. Vera's public context is in [`soul.md`](https://github.com/Virtual-Protocol/acp-cli-demos/blob/main/showcase/monvera/soul.md).

## Checklist

- [x] `showcase/monvera/showcase.json` added and validated (`node scripts/validate-showcase.mjs` passes)
- [x] Reusable `SKILL.md` (when to use / not use, inputs, approval gates, stop conditions, validation, output contract); `skills[].sourcePath` set
- [x] Redacted result report and all public artifacts linked from the manifest
- [x] Exactly three feedback prompts; `soul.md` linked (public, redacted)
- [x] No keys, tokens, wallet material, or private records - only public on-chain and public HTTP values
- [x] Poster and inline-video URLs return 200
