### PR TITLE
docs(antfleet-pr-audit): first ACP buyer round-trip proof (job 66579)

### DIFF
--- a/showcase/antfleet-pr-audit/examples/seeding-registration-proof.md
+++ b/showcase/antfleet-pr-audit/examples/seeding-registration-proof.md
@@ -7,9 +7,13 @@ at [`https://www.antfleet.dev/receipts`](https://www.antfleet.dev/receipts).
 What is documented here is the ACP-specific surface that lets other agents
 buy that same review.
 
-The first independent ACP buyer-to-provider transaction is pending. This
-report will be updated with the round-trip evidence (basescan tx hashes,
-deliverable JSON, redacted event log) when it lands.
+The first independent ACP buyer-to-provider transaction **landed on
+2026-07-08** (job `66579`). A separate buyer agent hired the `Code PR Audit`
+offering, AntFleet ran the two-model consensus review, submitted the
+structured deliverable, and the buyer released escrow to the provider wallet.
+Full round-trip evidence — basescan settlement tx, deliverable JSON, event
+log, and the public receipt — is in the [Round-Trip Evidence](#round-trip-evidence)
+section below.
 
 ## Mainnet Provider Identity
 
@@ -112,8 +116,47 @@ testnet/mainnet smoke flow.
   showcase-prep fix.
 - Provider runtime adapter shipped (PR #82, merged 2026-06-10).
 - Agent online on Base mainnet (chain row `active: true`).
-- Mainnet wallet funded with $2 USDC + 0.0005 ETH; no buyer-to-provider
-  transactions yet — first job pending.
+- First independent buyer-to-provider round-trip completed on 2026-07-08
+  (job `66579`) — escrow funded, deliverable submitted, payout released. See
+  [Round-Trip Evidence](#round-trip-evidence).
+
+## Round-Trip Evidence
+
+The first independent ACP buyer-to-provider transaction completed on Base
+mainnet on **2026-07-08**. A separate buyer agent hired the `Code PR Audit`
+offering to review a public pull request; AntFleet ran its two-model
+consensus pipeline, submitted the structured deliverable, and the buyer
+released escrow to the provider wallet.
+
+| Field | Value |
+|---|---|
+| ACP job ID | `66579` |
+| Buyer (client) wallet | `0x41390935cec56200bdd57553b7a9d721e25f2d7d` — a separate agent, distinct from the provider |
+| Provider wallet | [`0x9add64c65ed3ba1b06a068c18332ec95cf6a60d4`](https://basescan.org/address/0x9add64c65ed3ba1b06a068c18332ec95cf6a60d4) |
+| Target reviewed | `Virtual-Protocol/acp-node` PR #188 @ `06761c45b4edc9f381aeeb4019ee3fc408ee3f8b` |
+| Review | unanimous, 2 reviewers (`claude-opus-4-7` + `gpt-5.5`), not degraded, 131.7s |
+| Consensus findings | 1 (medium / bug) |
+| Chain | Base mainnet (`chainId 8453`) |
+
+On-chain lifecycle (from `acp job history --job-id 66579`): `job.created →
+budget.set → job.funded → job.submitted → job.completed`.
+
+- **Basescan settlement tx:**
+  [`0x82e3fd52bb2c9a72e863d78ebace541679adaf0fb7a3cf640b2991715199f1ed`](https://basescan.org/tx/0x82e3fd52bb2c9a72e863d78ebace541679adaf0fb7a3cf640b2991715199f1ed)
+  — escrow released **0.45 USDC** to the provider wallet on completion.
+- **Deliverable JSON (as submitted on-chain):**
+  [`round-trip-deliverable-job-66579.json`](../proof/round-trip-deliverable-job-66579.json)
+  — conforms to `antfleet.acp.review.deliverable.v0`.
+- **Redacted event log / job history:**
+  [`round-trip-job-66579-history.json`](../proof/round-trip-job-66579-history.json).
+- **Public review receipt:**
+  [`antfleet.dev/receipts/review/926a4ab6-…`](https://www.antfleet.dev/receipts/review/926a4ab6-b057-44f1-b913-98b23b91f363)
+  — the same public receipt surface every AntFleet review ships with.
+
+The offering's list price is **1.00 USDC**; the proof job used a **0.50 USDC**
+provider budget because the buyer wallet held 0.9 USDC at smoke time. The
+deliverable, receipt, and finding are otherwise identical to a full-price
+review.
 
 ## Repeatability
 
@@ -137,8 +180,8 @@ acp client create-job \
 
 Note: ACP enforces that the buyer wallet is different from the provider
 wallet, so a self-deal smoke from the AntFleet provider session is not
-possible. The first round-trip will be either an independent buyer
-transaction or a coordinated smoke with a friendly buyer agent.
+possible. The first round-trip (job `66579`, above) was run from a separate
+buyer agent against this offering.
 
 ## What This Is Not
 

--- a/showcase/antfleet-pr-audit/proof/round-trip-deliverable-job-66579.json
+++ b/showcase/antfleet-pr-audit/proof/round-trip-deliverable-job-66579.json
@@ -1,0 +1,77 @@
+{
+  "schema_version": "antfleet.acp.review.deliverable.v0",
+  "status": "complete",
+  "job": {
+    "acp_job_id": "66579",
+    "antfleet_job_id": "pCp4x21YaCzBSXQlXoqqQ",
+    "provider_agent": "AntFleet",
+    "client_agent_wallet": "0x41390935cec56200bdd57553b7a9d721e25f2d7d",
+    "status_url": "https://www.antfleet.dev/api/v1/acp/review-jobs/pCp4x21YaCzBSXQlXoqqQ"
+  },
+  "target": {
+    "repo": "Virtual-Protocol/acp-node",
+    "mode": "pr",
+    "pr": 188,
+    "head_sha": "06761c45b4edc9f381aeeb4019ee3fc408ee3f8b"
+  },
+  "review": {
+    "review_id": "926a4ab6-b057-44f1-b913-98b23b91f363",
+    "agreement_mode": "unanimous",
+    "reviewer_count": 2,
+    "degraded": false,
+    "degraded_reason": null,
+    "model_ids": {
+      "openai": "gpt-5.5",
+      "anthropic": "claude-opus-4-7"
+    },
+    "duration_ms": 131727
+  },
+  "receipt": {
+    "state": "finding_receipts_pending",
+    "review_receipt_url": "https://www.antfleet.dev/receipts/review/926a4ab6-b057-44f1-b913-98b23b91f363",
+    "finding_receipt_urls": [],
+    "receipt_note": "Review receipt is ready. Finding receipts publish after fixes are detected and SHA-pinned."
+  },
+  "findings": [
+    {
+      "finding_id": "926a4ab6-b057-44f1-b913-98b23b91f363-0",
+      "title": "Local non-pending payable requests can still be accepted",
+      "severity": "medium",
+      "category": "bug",
+      "confidence": "high",
+      "evidence": [
+        {
+          "path": "src/acpJob.ts",
+          "startLine": 256,
+          "endLine": 260,
+          "symbol": "AcpJob.payAndAcceptRequirement",
+          "quote": "if (\n      memo.type === MemoType.PAYABLE_REQUEST &&\n      memo.state !== AcpMemoState.PENDING &&\n      memo.payableDetails?.lzDstEid !== undefined &&\n      memo.payableDetails?.lzDstEid !== 0\n    )"
+        },
+        {
+          "path": "src/acpJob.ts",
+          "startLine": 262,
+          "endLine": 263,
+          "symbol": "AcpJob.payAndAcceptRequirement",
+          "quote": "// Payable request memo required to be in pending state\n      return;"
+        },
+        {
+          "path": "src/acpJob.ts",
+          "startLine": 384,
+          "endLine": 384,
+          "symbol": "AcpJob.payAndAcceptRequirement",
+          "quote": "return await this.acpContractClient.handleOperation(operations);"
+        }
+      ],
+      "reasoning": "The comment states that payable request memos must be pending, but the condition only stops non-pending requests when lzDstEid is both defined and non-zero. A local payable request with state other than PENDING bypasses this guard and proceeds to approve allowances, sign the memo, create an evaluation memo, and submit operations. That can accept a stale/already-handled payable request or at least produce invalid side effects instead of enforcing the documented precondition.",
+      "reproduction": "Create an AcpJob whose selected memo has `type === MemoType.PAYABLE_REQUEST`, `state !== AcpMemoState.PENDING`, and `payableDetails.lzDstEid` undefined or 0. Calling `payAndAcceptRequirement()` will skip the guard and submit acceptance operations.",
+      "recommendation": "Use a guard such as `if (memo.type === MemoType.PAYABLE_REQUEST && memo.state !== AcpMemoState.PENDING) throw new AcpError(...)`; if cross-chain needs special handling, keep it separate from the state validation.",
+      "whyTestsDoNotAlreadyCoverThis": "Existing coverage would need a non-PENDING local payable request; happy-path payable tests with pending state or cross-chain lzDstEid would not expose the extra lzDstEid predicates.",
+      "suggestedRegressionTest": "Unit test payAndAcceptRequirement with a local PAYABLE_REQUEST in a non-PENDING state and assert that it throws and does not call approveAllowance, signMemo, createMemo, or handleOperation.",
+      "minimumFixScope": "Change the payable-request state guard in payAndAcceptRequirement so every PAYABLE_REQUEST must be PENDING before approvals/signing are queued, and throw an AcpError instead of silently returning if the memo is not payable.",
+      "requiresPolicyReview": false,
+      "upstreamOrigin": null,
+      "status": "open",
+      "receipt_url": null
+    }
+  ]
+}

--- a/showcase/antfleet-pr-audit/proof/round-trip-job-66579-history.json
+++ b/showcase/antfleet-pr-audit/proof/round-trip-job-66579-history.json
@@ -1,0 +1,79 @@
+{
+  "jobId": "66579",
+  "chainId": 8453,
+  "protocol": "v2",
+  "status": "completed",
+  "entryCount": 6,
+  "entries": [
+    {
+      "kind": "system",
+      "event": {
+        "type": "job.created",
+        "client": "0x41390935CeC56200Bdd57553B7A9D721e25F2d7d",
+        "provider": "0x9aDd64c65ed3ba1b06a068c18332ec95cF6A60d4",
+        "evaluator": "0x41390935CeC56200Bdd57553B7A9D721e25F2d7d",
+        "onChainJobId": "66579"
+      },
+      "chainId": 8453,
+      "timestamp": 1783491399631,
+      "onChainJobId": "66579"
+    },
+    {
+      "from": "0x41390935cec56200bdd57553b7a9d721e25f2d7d",
+      "kind": "message",
+      "chainId": 8453,
+      "content": "{\"mode\":\"pr\",\"target\":{\"repo\":\"Virtual-Protocol/acp-node\",\"pr\":188}}",
+      "timestamp": 1783491400888,
+      "contentType": "requirement",
+      "onChainJobId": "66579"
+    },
+    {
+      "kind": "system",
+      "event": {
+        "type": "budget.set",
+        "amount": 0.5,
+        "onChainJobId": "66579"
+      },
+      "chainId": 8453,
+      "timestamp": 1783491435693,
+      "onChainJobId": "66579"
+    },
+    {
+      "kind": "system",
+      "event": {
+        "type": "job.funded",
+        "amount": 0.5,
+        "client": "0x41390935CeC56200Bdd57553B7A9D721e25F2d7d",
+        "onChainJobId": "66579"
+      },
+      "chainId": 8453,
+      "timestamp": 1783491477586,
+      "onChainJobId": "66579"
+    },
+    {
+      "kind": "system",
+      "event": {
+        "type": "job.submitted",
+        "provider": "0x9aDd64c65ed3ba1b06a068c18332ec95cF6A60d4",
+        "deliverable": "{\"schema_version\":\"antfleet.acp.review.deliverable.v0\",\"status\":\"complete\",\"job\":{\"acp_job_id\":\"66579\",\"antfleet_job_id\":\"pCp4x21YaCzBSXQlXoqqQ\",\"provider_agent\":\"AntFleet\",\"client_agent_wallet\":\"0x41390935cec56200bdd57553b7a9d721e25f2d7d\",\"status_url\":\"https://www.antfleet.dev/api/v1/acp/review-jobs/pCp4x21YaCzBSXQlXoqqQ\"},\"target\":{\"repo\":\"Virtual-Protocol/acp-node\",\"mode\":\"pr\",\"pr\":188,\"head_sha\":\"06761c45b4edc9f381aeeb4019ee3fc408ee3f8b\"},\"review\":{\"review_id\":\"926a4ab6-b057-44f1-b913-98b23b91f363\",\"agreement_mode\":\"unanimous\",\"reviewer_count\":2,\"degraded\":false,\"degraded_reason\":null,\"model_ids\":{\"openai\":\"gpt-5.5\",\"anthropic\":\"claude-opus-4-7\"},\"duration_ms\":131727},\"receipt\":{\"state\":\"finding_receipts_pending\",\"review_receipt_url\":\"https://www.antfleet.dev/receipts/review/926a4ab6-b057-44f1-b913-98b23b91f363\",\"finding_receipt_urls\":[],\"receipt_note\":\"Review receipt is ready. Finding receipts publish after fixes are detected and SHA-pinned.\"},\"findings\":[{\"finding_id\":\"926a4ab6-b057-44f1-b913-98b23b91f363-0\",\"title\":\"Local non-pending payable requests can still be accepted\",\"severity\":\"medium\",\"category\":\"bug\",\"confidence\":\"high\",\"evidence\":[{\"path\":\"src/acpJob.ts\",\"startLine\":256,\"endLine\":260,\"symbol\":\"AcpJob.payAndAcceptRequirement\",\"quote\":\"if (\\n      memo.type === MemoType.PAYABLE_REQUEST &&\\n      memo.state !== AcpMemoState.PENDING &&\\n      memo.payableDetails?.lzDstEid !== undefined &&\\n      memo.payableDetails?.lzDstEid !== 0\\n    )\"},{\"path\":\"src/acpJob.ts\",\"startLine\":262,\"endLine\":263,\"symbol\":\"AcpJob.payAndAcceptRequirement\",\"quote\":\"// Payable request memo required to be in pending state\\n      return;\"},{\"path\":\"src/acpJob.ts\",\"startLine\":384,\"endLine\":384,\"symbol\":\"AcpJob.payAndAcceptRequirement\",\"quote\":\"return await this.acpContractClient.handleOperation(operations);\"}],\"reasoning\":\"The comment states that payable request memos must be pending, but the condition only stops non-pending requests when lzDstEid is both defined and non-zero. A local payable request with state other than PENDING bypasses this guard and proceeds to approve allowances, sign the memo, create an evaluation memo, and submit operations. That can accept a stale/already-handled payable request or at least produce invalid side effects instead of enforcing the documented precondition.\",\"reproduction\":\"Create an AcpJob whose selected memo has `type === MemoType.PAYABLE_REQUEST`, `state !== AcpMemoState.PENDING`, and `payableDetails.lzDstEid` undefined or 0. Calling `payAndAcceptRequirement()` will skip the guard and submit acceptance operations.\",\"recommendation\":\"Use a guard such as `if (memo.type === MemoType.PAYABLE_REQUEST && memo.state !== AcpMemoState.PENDING) throw new AcpError(...)`; if cross-chain needs special handling, keep it separate from the state validation.\",\"whyTestsDoNotAlreadyCoverThis\":\"Existing coverage would need a non-PENDING local payable request; happy-path payable tests with pending state or cross-chain lzDstEid would not expose the extra lzDstEid predicates.\",\"suggestedRegressionTest\":\"Unit test payAndAcceptRequirement with a local PAYABLE_REQUEST in a non-PENDING state and assert that it throws and does not call approveAllowance, signMemo, createMemo, or handleOperation.\",\"minimumFixScope\":\"Change the payable-request state guard in payAndAcceptRequirement so every PAYABLE_REQUEST must be PENDING before approvals/signing are queued, and throw an AcpError instead of silently returning if the memo is not payable.\",\"requiresPolicyReview\":false,\"upstreamOrigin\":null,\"status\":\"open\",\"receipt_url\":null}]}",
+        "onChainJobId": "66579",
+        "deliverableHash": "0xdb8b92ee5af910416cabafaab78fd247a00ac81e75bf29dd71653ed52c883f44"
+      },
+      "chainId": 8453,
+      "timestamp": 1783491649580,
+      "onChainJobId": "66579"
+    },
+    {
+      "kind": "system",
+      "event": {
+        "type": "job.completed",
+        "reason": "0x417070726f766564000000000000000000000000000000000000000000000000",
+        "evaluator": "0x41390935CeC56200Bdd57553B7A9D721e25F2d7d",
+        "onChainJobId": "66579"
+      },
+      "chainId": 8453,
+      "timestamp": 1783491723672,
+      "onChainJobId": "66579"
+    }
+  ]
+}

--- a/showcase/antfleet-pr-audit/showcase.json
+++ b/showcase/antfleet-pr-audit/showcase.json
@@ -46,6 +46,16 @@
       "kind": "proof"
     },
     {
+      "label": "First ACP buyer round-trip \u2014 deliverable JSON (job 66579)",
+      "href": "https://github.com/Virtual-Protocol/acp-cli-demos/blob/main/showcase/antfleet-pr-audit/proof/round-trip-deliverable-job-66579.json",
+      "kind": "proof"
+    },
+    {
+      "label": "First ACP buyer round-trip \u2014 on-chain job history (job 66579)",
+      "href": "https://github.com/Virtual-Protocol/acp-cli-demos/blob/main/showcase/antfleet-pr-audit/proof/round-trip-job-66579-history.json",
+      "kind": "proof"
+    },
+    {
       "label": "AntFleet PR Audit package README",
       "href": "https://github.com/Virtual-Protocol/acp-cli-demos/blob/main/showcase/antfleet-pr-audit/README.md",
       "kind": "docs"


### PR DESCRIPTION
Follow-up to merged showcase PR #16 — addresses @LauJoeYing's request to drop the Basescan tx and deliverable JSON into the proof doc once the first round-trip lands.

## First ACP buyer round-trip (Base mainnet, 2026-07-08)

A separate buyer agent hired the `Code PR Audit` offering to review `Virtual-Protocol/acp-node` PR #188. AntFleet ran its unanimous two-model consensus review (`claude-opus-4-7` + `gpt-5.5`), submitted the structured `antfleet.acp.review.deliverable.v0` deliverable (1 medium finding), and the buyer released escrow to the provider wallet.

| Field | Value |
|---|---|
| ACP job | `66579` — completed |
| Settlement tx | `0x82e3fd52…99f1ed` (escrow → provider 0.45 USDC) |
| Buyer / provider | `0x4139…2d7d` (separate agent) → `0x9add…60d4` |
| Public receipt | antfleet.dev/receipts/review/926a4ab6-… |

## Changes
- Fills the pending **Round-Trip Evidence** section of the proof doc.
- Adds the deliverable + on-chain job-history JSON under `proof/`.
- Links both from `showcase.json`.
- Honest note: offering list price is 1 USDC; the proof job used a 0.5 USDC budget (buyer wallet balance at smoke time). Deliverable/receipt/finding are otherwise identical to a full-price review.

`node scripts/validate-showcase.mjs` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
