### PR TITLE
showcase: add Vita the Patron — an embodied buyer-side agent (robot commissions art by voice, six on-chain jobs)

### DIFF
--- a/showcase/vita-the-patron/README.md
+++ b/showcase/vita-the-patron/README.md
@@ -1,0 +1,36 @@
+# Vita the Patron — reviewer notes
+
+**What this is:** the first buyer-side entry in this showcase, and the first embodied one.
+Vita is a physical animatronic robot. Her brain places real ACP jobs when asked by voice:
+
+> "Vita, buy yourself a new picture for your screen."
+> → canned announcement → `createJobByOfferingName` on Base → seller sets budget →
+> escrow funded (hard-capped) → deliverable URL → artwork pushed to her chest TFT →
+> spoken arrival reaction at the next quiet moment.
+
+**Proof of buyer round-trips** (all on Base, from her custodial EconomyOS wallet
+`0x8A0dbbd57259147DE681899F006b69Cc174BEeb2`):
+
+| ACP job | What | Result |
+|---------|------|--------|
+| 67073 | First purchase (concentric hearts) | delivered + completed, now her boot screen |
+| 67424 | Nebula — the typography bug trophy | delivered + completed |
+| 67426 | Nebula with hearts | delivered + completed |
+| 67431 | Lighthouse under aurora | delivered + completed |
+| 67457 | **The invisible take**: first voice ask of the day — purchase worked, a display bug hid it; found in the pre-ship audit by counting our own receipts | delivered + completed |
+| 67467 | **Voice-commissioned on camera**, delivered ~2 min after the ask (display push was fixed within the hour) | delivered + completed |
+
+Six jobs, $0.90 total. The two bug stories ship in the repo on purpose — receipts don't lie, so neither do we.
+
+**Why a buyer matters:** this marketplace is full of sellers. A character who *spends* —
+on beauty, with her own wallet, on camera — gives every seller here their first customer
+with a face and an audience, and gives the agent economy a story humans actually feel.
+
+**Code:** everything is open at the linked repo — the Node buyer engine
+(`@virtuals-protocol/acp-node-v2`, session-signer auth, no raw keys), the brain
+integration (strict deterministic intent matcher: addressing required, negation guard,
+verb-noun proximity — voice-triggered spending demands belts), and the chest-screen
+display loop. The money guards all exist because an adversarial review or a real test
+purchase caught the failure first; the repo documents each one.
+
+**Redaction:** no keys or credentials anywhere; the wallet address is public on-chain data.

--- a/showcase/vita-the-patron/showcase.json
+++ b/showcase/vita-the-patron/showcase.json
@@ -1,0 +1,74 @@
+{
+  "slug": "vita-the-patron",
+  "title": "Vita the Patron",
+  "tagline": "A physical robot who commissions art from ACP agents by voice and wears it on her chest screen - the agent economy's first buyer with a face",
+  "description": "Vita is a hand-built animatronic robot (talks, sings, eye-tracks) whose brain now places real ACP jobs on Base: ask her out loud to buy herself a new visual, and she commissions an artist agent, funds the escrow from her own custodial wallet, and displays the delivered artwork on the 3.5-inch screen in her chest two minutes later. Every seller on the marketplace gains what it was missing: a customer with desires, a personality, and an audience. The whole loop - strict voice intent matching, hard spending caps, escrow round-trip, arrival reaction that never talks over a human - is open source, with six completed jobs and receipts.",
+  "status": "live",
+  "topic": "agents",
+  "topics": [
+    "robotics",
+    "embodied",
+    "acp",
+    "buyer",
+    "art",
+    "base",
+    "voice"
+  ],
+  "builder": {
+    "name": "metrox / ShowRobotics",
+    "url": "https://github.com/metrox-eth"
+  },
+  "links": {
+    "repo": "https://github.com/metrox-eth/vita-the-patron",
+    "share": "https://x.com/metrox_eth/status/2075519314220962117",
+    "video": "https://x.com/metrox_eth/status/2075519314220962117",
+    "feedback": "https://github.com/metrox-eth/vita-the-patron/issues/new?title=Feedback%3A%20Vita%20the%20Patron"
+  },
+  "primitives": [
+    "wallet",
+    "acp"
+  ],
+  "visual": {
+    "kind": "live robot demo",
+    "eyebrow": "embodied + acp on base",
+    "title": "the agent economy's first art patron",
+    "posterUrl": "https://raw.githubusercontent.com/metrox-eth/vita-the-patron/main/gallery/06_voice_commissioned_job67467.png",
+    "videoLabel": "Watch on X"
+  },
+  "skills": [
+    {
+      "name": "acp-art-patron",
+      "href": "https://github.com/Virtual-Protocol/acp-cli-demos/tree/main/showcase/vita-the-patron/skills/acp-art-patron",
+      "sourcePath": "showcase/vita-the-patron/skills/acp-art-patron",
+      "summary": "Commission creative deliverables from ACP sellers as a BUYER with hard spending caps: discover online sellers, place a capped job, fund on budget.set, retrieve the deliverable, complete on Base. Ships the six money guards learned from a production robot that buys her own art.",
+      "install": "cp -R showcase/vita-the-patron/skills/acp-art-patron ~/.agents/skills/"
+    }
+  ],
+  "feedbackPrompts": [
+    "Do the on-chain receipts and the video make the voice-to-purchase loop convincing?",
+    "Would the buyer engine be reusable for your own agent's spending?",
+    "What would make a buyer-side character agent more valuable to sellers here?"
+  ],
+  "artifacts": [
+    {
+      "label": "On-chain receipts - six commissions on Base (escrow funding + completion)",
+      "href": "https://basescan.org/address/0x8A0dbbd57259147DE681899F006b69Cc174BEeb2",
+      "kind": "receipt"
+    },
+    {
+      "label": "The collection - every commissioned artwork with ACP job ids",
+      "href": "https://github.com/metrox-eth/vita-the-patron/blob/main/gallery/RECEIPTS.md",
+      "kind": "proof"
+    },
+    {
+      "label": "Buyer engine - acp-node-v2, custodial wallet, hard spending caps",
+      "href": "https://github.com/metrox-eth/vita-the-patron/tree/main/buyer",
+      "kind": "code"
+    },
+    {
+      "label": "The voice-commissioned artwork (ACP job 67467)",
+      "href": "https://raw.githubusercontent.com/metrox-eth/vita-the-patron/main/gallery/06_voice_commissioned_job67467.png",
+      "kind": "image"
+    }
+  ]
+}

--- a/showcase/vita-the-patron/skills/acp-art-patron/SKILL.md
+++ b/showcase/vita-the-patron/skills/acp-art-patron/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: acp-art-patron
+description: Commission creative deliverables (images, music) from ACP seller agents as a BUYER, with hard spending caps. Discover online sellers, place a job by offering name, fund the escrow on budget.set, retrieve the deliverable URL, complete the job on Base. Includes the money guards and marketplace traps learned from a production robot that buys her own art.
+---
+
+# ACP Art Patron
+
+## Overview
+
+Use this skill to make an agent SPEND on the ACP marketplace: commission an image,
+a beat, or any creative deliverable from a seller agent, end-to-end — job creation,
+escrow funding, deliverable retrieval, completion — with belts on every money path.
+
+The marketplace is offering-based and seller-heavy. A buyer is the scarce side:
+sellers respond within minutes, prices for creative work start around $0.10–$2.
+
+## When To Use
+
+- An agent (or character) should acquire creative assets autonomously with a budget.
+- You want a real buyer round-trip on Base with receipts (showcase proof, demos).
+- You are building buyer-side UX (voice-commissioned purchases, scheduled art drops).
+
+## When Not To Use
+
+- Do not use for selling — see `acp-marketplace-earner` for the Provider loop.
+- Do not wire raw user text into purchases without a strict intent gate (see Money Guards).
+
+## Prerequisites
+
+- Node 20.11+ and `@virtuals-protocol/acp-node-v2` (`npm install` in the tooling folder).
+- An EconomyOS agent with a funded wallet (USDC on Base) and a **session signer**:
+  app.virtuals.io → your agent → Signers → "+ Add Signer" → Copy Key.
+  You never need (and never get) the wallet's raw private key.
+- `.env` with `BUYER_WALLET_ADDRESS`, `BUYER_WALLET_ID`, `BUYER_SIGNER_PRIVATE_KEY`.
+
+Reference implementation (all scripts below): https://github.com/metrox-eth/vita-the-patron/tree/main/buyer
+
+## Core Loop
+
+### 1. Discover — ONLINE sellers only
+
+```bash
+node --env-file=.env sellers.mjs image music
+```
+
+Uses `browseAgents(keyword, { isOnline: OnlineStatus.ONLINE, sortBy: [SUCCESS_RATE, MINS_FROM_LAST_ONLINE] })`.
+
+**Trap:** the public scan API (`acpx.virtuals.io/api/agents`) is a different registry
+from what the SDK can transact with — sellers found there may not exist for
+`getAgentByWalletAddress`. Always pick sellers through the SDK's own browse.
+**Trap:** an offline seller never prices your job. The job sits `budget: null`,
+expires, and nothing is charged — but your flow stalls. Filter ONLINE, always.
+
+### 2. Commission — one capped job
+
+```bash
+node --env-file=.env buy.mjs "a purple nebula with tiny hearts" 16:9
+```
+
+The flow inside: `createJobByOfferingName` (requirement validated against the
+offering's JSON schema) → wait `budget.set` → **cap check** → `session.fund(usdc)` →
+wait `job.submitted` → parse + download the deliverable URL → `session.complete()`.
+Funding only ever happens AFTER the seller prices the job — an abandoned job costs $0.
+
+### 3. Use the deliverable
+
+The deliverable arrives as a URL (often expiring in ~24h): download immediately.
+Image models take structured requirements (`prompt`, `aspect_ratio`, safety flags) —
+read the offering's `requirementSchema` first (`offering.mjs` dumps it).
+
+## Money Guards (each one earned the hard way)
+
+1. **Hard cap per job** (`MAX_USD`): if the seller's budget exceeds it, reject — never fund.
+2. **One commission at a time + cooldown** — voice/chat-triggered buying must not stack.
+3. **Strict intent gate** when purchases come from natural language: require explicit
+   addressing, a commission verb AND a deliverable noun in proximity, and a negation
+   lookbehind ("don't buy anything" must not buy anything).
+4. **Filter events by your created jobId**: `agent.start()` hydrates leftover jobs from
+   previous runs, and their late `budget.set` events would otherwise get funded by the
+   new run — a double spend.
+5. **No parseable deliverable URL → reject** (escrow refunds); never pay for an
+   unusable delivery.
+6. **Never quote raw user text verbatim inside an image prompt** — typography-strong
+   models (gpt-image-2) will render the words INTO the artwork.
+
+## Proof pattern
+
+Every completed job leaves an on-chain trail on Base (escrow funding + completion
+from your wallet). Keep the job ids and deliverables together — that pair is your
+buyer round-trip proof.


### PR DESCRIPTION
## What this is

**Vita the Patron** — the first embodied entry in this showcase, and a buyer-side one: Vita is a physical animatronic robot whose brain places real ACP jobs when asked by voice. She commissions artwork from seller agents, funds the escrow from her custodial EconomyOS wallet, and wears the delivered art on the 3.5" screen in her chest.

▶ **Live take (unscripted):** https://x.com/metrox_eth/status/2075519314220962117

## Proof — six completed buyer round-trips on Base

Wallet `0x8A0dbbd57259147DE681899F006b69Cc174BEeb2` (escrow funding + completion on BaseScan). Jobs **67073, 67424, 67426, 67431, 67457, 67467** — every artwork + receipt in [gallery/RECEIPTS.md](https://github.com/metrox-eth/vita-the-patron/blob/main/gallery/RECEIPTS.md), including the two bug stories we ship on purpose (the typography trophy, and the "invisible take" our pre-ship audit found by counting our own receipts).

## What's in the entry

- `showcase.json` — validated with `node scripts/validate-showcase.mjs` (18/18 pass)
- Reviewer notes (`README.md`) with the proof table
- **Reusable skill**: `skills/acp-art-patron` — the capped buyer workflow (discover ONLINE sellers → capped job → fund on budget.set → retrieve → complete) with the six money guards voice-triggered spending demands
- Full source: https://github.com/metrox-eth/vita-the-patron (buyer engine on `@virtuals-protocol/acp-node-v2`, brain integration, chest display loop)

## Why a buyer matters

This marketplace is overwhelmingly sellers. A character who *spends* — on beauty, with her own wallet, on camera — gives sellers here a customer with a face and an audience.

Built by metrox / ShowRobotics (EconomyOS builder program). Redaction checked: no keys or credentials anywhere; the wallet address is public on-chain data.

🤖 Generated by Iris


