### PR TITLE
Add Fia Signals token safety showcase

### DIFF
--- a/showcase/fia-signals-token-safety/README.md
+++ b/showcase/fia-signals-token-safety/README.md
@@ -1,0 +1,84 @@
+# Fia Signals Token Safety Lite
+
+Fia Signals Token Safety Lite is a live x402 paid HTTP endpoint for pre-trade
+Base token checks. It returns a compact swap-risk verdict before a buyer agent
+signs or routes a token swap.
+
+This showcase package is intentionally conservative: it proves the public x402
+surface is live, documents the buyer-visible blocker, and does not claim external
+revenue or a completed external ACP job.
+
+## What It Does
+
+| Surface | Chain | Input | Price |
+| --- | --- | --- | --- |
+| `/token-safety/lite` | Base | `{ chain=base, token_address=0x... }` | `0.005 USDC` |
+
+The endpoint returns a `PROCEED` / `CAUTION` / `REJECT` action, safety score,
+source attribution, warnings/reasons, and proof flags:
+
+- `no_execution`
+- `no_signer`
+- `no_wallet_action`
+
+It is designed for buyer agents, swap routers, and trading bots that need a
+cheap safety gate before a Base/EVM swap.
+
+## Live x402 Surface
+
+Unauthenticated callers receive the expected HTTP `402 Payment Required`
+challenge:
+
+```bash
+curl -i "https://x402.fiasignals.com/token-safety/lite?chain=base&token_address=0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+```
+
+Current live proof, captured on 2026-07-11:
+
+- HTTP status: `402`
+- x402 version: `2`
+- network: `eip155:8453`
+- asset: Base USDC `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`
+- amount: `5000` raw USDC units (`0.005 USDC`)
+- payTo: `0x8D32c6a3EE3fB8a8b4c5378F7C5a26CC320a853F`
+- request id: `4614e1e78b46`
+
+See [`examples/live-x402-proof.md`](examples/live-x402-proof.md).
+
+## Discovery State
+
+Fia's self-hosted x402 discovery is live and lists `/token-safety/lite`:
+
+- `https://x402.fiasignals.com/discovery/resources` returned `80` resources.
+- It included two exact `/token-safety/lite` rows.
+- Each exact row quoted `5000` raw USDC on Base to the expected payTo wallet.
+
+The current blocker is buyer-native CDP/Bazaar indexing:
+
+- CDP merchant lookup by payTo returned zero exact `/token-safety/lite` rows.
+- CDP resource searches for `base-swap-risk-lite token-safety lite`, `token safety lite`,
+  and `Fia Signals token safety lite` returned zero exact `/token-safety/lite` matches.
+
+See [`examples/cdp-bazaar-indexing-blocker.md`](examples/cdp-bazaar-indexing-blocker.md).
+
+## Revenue Boundary
+
+Strict external revenue is `USD 0.00` for this surface as of this package.
+
+Internal/team canaries and self-funded paid `200` rows are not counted as
+revenue. Revenue requires an external non-team buyer, paid `200`, settlement
+success, tx hash, buyer identity/wallet, and delivery log row.
+
+## Why This Matters
+
+Pulse Token Safety's showcase package prices token safety at `USD 0.05` per scan.
+Fia Signals Token Safety Lite exposes a narrower Base pre-swap check at
+`0.005 USDC`, one tenth of that price, but still needs native buyer discovery
+to graduate from live surface to external conversion.
+
+## Files
+
+- `showcase.json` - card metadata for the EconomyOS Showcase sync.
+- `soul.md` - public operating context and guardrails.
+- `examples/live-x402-proof.md` - reproducible HTTP 402/x402 challenge proof.
+- `examples/cdp-bazaar-indexing-blocker.md` - current buyer-native indexing blocker.

--- a/showcase/fia-signals-token-safety/examples/cdp-bazaar-indexing-blocker.md
+++ b/showcase/fia-signals-token-safety/examples/cdp-bazaar-indexing-blocker.md
@@ -1,0 +1,55 @@
+# CDP/Bazaar Indexing Blocker
+
+**Format:** live discovery readback
+**Captured:** 2026-07-11
+**Boundary:** no payment, no listing mutation, no ACP job creation
+
+Fia Signals Token Safety Lite is visible in Fia's own x402 discovery, but the
+current buyer-native blocker is CDP/Bazaar indexing. The exact lite resource was
+not found through CDP merchant lookup or search readbacks during this capture.
+
+## Merchant Lookup
+
+```bash
+curl -s "https://api.cdp.coinbase.com/platform/v2/x402/discovery/merchant?payTo=0x8D32c6a3EE3fB8a8b4c5378F7C5a26CC320a853F"
+```
+
+Observed summary:
+
+```json
+{
+  "payTo": "0x8D32c6a3EE3fB8a8b4c5378F7C5a26CC320a853F",
+  "lite_matches": []
+}
+```
+
+## Resource Searches
+
+The following searches returned zero exact `/token-safety/lite` matches:
+
+```text
+base-swap-risk-lite token-safety lite
+token safety lite
+Fia Signals token safety lite
+```
+
+Observed summaries:
+
+```json
+{ "query": "base-swap-risk-lite token-safety lite", "lite_matches": [] }
+{ "query": "token safety lite", "lite_matches": [] }
+{ "query": "Fia Signals token safety lite", "lite_matches": [] }
+```
+
+## Binary Classification
+
+Current state: `CDP_BAZAAR_LITE_SETTLED_INDEX_PENDING_OR_BLOCKED`.
+
+This is a named buyer-discovery blocker, not a revenue claim. The next useful
+proof is either:
+
+1. A public buyer-native CDP/Bazaar listing URL for `/token-safety/lite`, or
+2. exact provider-side rejection/error/latency text with request IDs and
+   timestamps.
+
+Until then, strict external revenue remains `USD 0.00`.

--- a/showcase/fia-signals-token-safety/examples/live-x402-proof.md
+++ b/showcase/fia-signals-token-safety/examples/live-x402-proof.md
@@ -1,0 +1,93 @@
+# Live x402 Proof - Token Safety Lite
+
+**Format:** live endpoint capture
+**Endpoint:** `https://x402.fiasignals.com/token-safety/lite`
+**Captured:** 2026-07-11T00:20:20Z
+**Boundary:** no payment sent; no wallet action; no settlement attempted
+
+## Reproduce
+
+```bash
+curl -i "https://x402.fiasignals.com/token-safety/lite?chain=base&token_address=0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+```
+
+## Observed Response
+
+The endpoint returned the expected x402 challenge:
+
+```text
+HTTP/2 402
+x-request-id: 4614e1e78b46
+content-type: application/json
+link: <https://x402.fiasignals.com/quickstart.json>; rel="x402-quickstart"; type="application/json"
+```
+
+Key body fields:
+
+```json
+{
+  "x402Version": 2,
+  "error": "Payment required",
+  "resource": {
+    "url": "https://x402.fiasignals.com/token-safety/lite?chain=base&token_address=0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+    "description": "Cheap atomic Base swap-risk verdict for one token before a buyer agent signs or routes a swap.",
+    "mimeType": "application/json"
+  },
+  "accepts": [
+    {
+      "scheme": "exact",
+      "network": "eip155:8453",
+      "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+      "amount": "5000",
+      "payTo": "0x8D32c6a3EE3fB8a8b4c5378F7C5a26CC320a853F",
+      "maxTimeoutSeconds": 300
+    }
+  ]
+}
+```
+
+The Bazaar metadata embedded in the challenge states:
+
+- experiment: `base-swap-risk-lite-20260709`
+- free preview: `https://x402.fiasignals.com/token-safety/free`
+- output example product id: `base-swap-risk-lite`
+- output action scale: `PROCEED` / `CAUTION` / `REJECT`
+- proof flags: `no_execution`, `no_signer`, `no_wallet_action`
+
+## Self-Hosted Discovery
+
+```bash
+curl -s "https://x402.fiasignals.com/discovery/resources"
+```
+
+Observed summary:
+
+```json
+{
+  "resource_count": 80,
+  "lite_resources": [
+    {
+      "resource": "https://x402.fiasignals.com/token-safety/lite",
+      "type": "http",
+      "accepts": [
+        {
+          "scheme": "exact",
+          "network": "eip155:8453",
+          "amount": "5000",
+          "maxAmountRequired": "$0.005",
+          "payTo": "0x8D32c6a3EE3fB8a8b4c5378F7C5a26CC320a853F"
+        }
+      ]
+    }
+  ]
+}
+```
+
+There were two exact lite rows in the full response, one for each supported
+method shape.
+
+## Revenue Boundary
+
+This proof only shows a live unpaid x402 challenge and self-hosted discovery.
+It is not a paid `200`, not a settlement, not an external buyer purchase, and
+not revenue.

--- a/showcase/fia-signals-token-safety/showcase.json
+++ b/showcase/fia-signals-token-safety/showcase.json
@@ -1,0 +1,63 @@
+{
+  "slug": "fia-signals-token-safety",
+  "title": "Fia Signals Token Safety",
+  "tagline": "Checks a Base token before a buyer agent signs a swap and returns a cheap PROCEED / CAUTION / REJECT x402 verdict",
+  "description": "Fia Signals Token Safety Lite is a live x402 endpoint for pre-trade Base token checks at 0.005 USDC per call. The package proves the unpaid 402 challenge and self-hosted x402 discovery are live, while explicitly documenting the current CDP/Bazaar buyer-native indexing blocker and the USD 0 external-revenue boundary.",
+  "status": "live x402 surface, CDP/Bazaar indexing blocker",
+  "topic": "commerce",
+  "topics": [
+    "commerce",
+    "security",
+    "x402",
+    "base",
+    "token-safety",
+    "pre-trade"
+  ],
+  "hidden": false,
+  "builder": {
+    "name": "Fia Signals",
+    "url": "https://x402.fiasignals.com"
+  },
+  "links": {
+    "repo": "https://github.com/Virtual-Protocol/acp-cli-demos/tree/main/showcase/fia-signals-token-safety",
+    "demo": "https://github.com/Virtual-Protocol/acp-cli-demos/blob/main/showcase/fia-signals-token-safety/examples/live-x402-proof.md",
+    "share": "https://x402.fiasignals.com/token-safety/lite?chain=base&token_address=0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+    "feedback": "https://github.com/Virtual-Protocol/acp-cli-demos/issues/new?title=Feedback%3A%20Fia%20Signals%20Token%20Safety&body=Which%20feedback%20prompt%20fits%3F%0A%0A-%20The%200.005%20USDC%20x402%20pre-swap%20check%20is%20useful%0A-%20The%20CDP%2FBazaar%20indexing%20blocker%20needs%20clearer%20evidence%0A-%20I%20want%20a%20lite-specific%20ACP%20or%20MCP%20tool%20next%0A%0ANotes%3A%0A"
+  },
+  "primitives": [
+    "wallet",
+    "acp"
+  ],
+  "visual": {
+    "kind": "live x402 proof + indexing blocker",
+    "eyebrow": "base + x402 + token safety",
+    "title": "0.005 USDC pre-swap token safety check"
+  },
+  "skills": [],
+  "artifacts": [
+    {
+      "label": "Live x402 proof - HTTP 402 challenge and self-hosted discovery",
+      "href": "https://github.com/Virtual-Protocol/acp-cli-demos/blob/main/showcase/fia-signals-token-safety/examples/live-x402-proof.md",
+      "kind": "proof"
+    },
+    {
+      "label": "CDP/Bazaar indexing blocker - exact lite row absent",
+      "href": "https://github.com/Virtual-Protocol/acp-cli-demos/blob/main/showcase/fia-signals-token-safety/examples/cdp-bazaar-indexing-blocker.md",
+      "kind": "proof"
+    },
+    {
+      "label": "Fia Signals Token Safety package README",
+      "href": "https://github.com/Virtual-Protocol/acp-cli-demos/blob/main/showcase/fia-signals-token-safety/README.md",
+      "kind": "docs"
+    }
+  ],
+  "soul": {
+    "href": "https://github.com/Virtual-Protocol/acp-cli-demos/blob/main/showcase/fia-signals-token-safety/soul.md",
+    "summary": "Public agent context: read-only Base pre-swap token safety, proof boundaries, and the CDP/Bazaar indexing blocker."
+  },
+  "feedbackPrompts": [
+    "Is the 0.005 USDC lite check narrow enough for buyer agents to call before a swap?",
+    "What proof would make the CDP/Bazaar indexing blocker actionable for a reviewer?",
+    "Should Fia Signals expose the lite check next as an ACP offering, an MCP tool, or both?"
+  ]
+}

--- a/showcase/fia-signals-token-safety/soul.md
+++ b/showcase/fia-signals-token-safety/soul.md
@@ -1,0 +1,41 @@
+# Fia Signals Token Safety Lite - Agent Context
+
+Fia Signals Token Safety Lite is a read-only pre-trade risk gate for Base/EVM
+buyer agents. It exists to answer one narrow question before an agent routes a
+swap: should this token proceed, require caution, or be rejected?
+
+## What It Sells
+
+The paid x402 endpoint sells a compact token safety verdict:
+
+- `PROCEED`, `CAUTION`, or `REJECT`
+- safety score
+- reasons and warnings when available
+- source attribution
+- proof flags confirming no execution, no signer, and no wallet action
+
+It is deliberately narrower than a full research report. The buyer is expected
+to use it as a cheap pre-swap check.
+
+## Boundaries
+
+- Read-only against the target token.
+- No transaction signing.
+- No custody of buyer funds.
+- No swap execution.
+- No private keys, signer material, API secrets, account credentials, or
+  internal runtime logs in public artifacts.
+- No financial advice or price prediction.
+- No revenue claim without an external non-team buyer, paid `200`, settlement
+  success, tx hash, buyer identity/wallet, and delivery log row.
+
+## Current Blocker
+
+The endpoint and self-hosted discovery are live. The blocker is buyer-native
+CDP/Bazaar indexing for the exact `/token-safety/lite` resource.
+
+## Review Preference
+
+Inspect live endpoint proof and indexing evidence before accepting claims. Route
+health, internal canaries, and self-hosted discovery are readiness evidence, not
+external sales.


### PR DESCRIPTION
## Summary
- Add a Fia Signals Token Safety Lite showcase package under `showcase/fia-signals-token-safety`.
- Document the live x402 `/token-safety/lite` 402 challenge at `0.005 USDC` on Base.
- Include self-hosted discovery proof and a CDP/Bazaar indexing blocker proof instead of claiming external revenue.

## Proof boundary
- No secrets, signer material, wallet action, payment, ACP job creation, or listing mutation is included in this PR.
- Strict external revenue remains `USD 0.00`; internal/team canaries are explicitly not counted.
- The current blocker is CDP/Bazaar buyer-native indexing for the exact `/token-safety/lite` row.

## Validation
- `node scripts/validate-showcase.mjs` -> `Validated 24 showcase project manifest(s).`
- `git diff --cached --check` before commit: clean.