### PR TITLE
showcase(vita-the-patron): add-on — the buyer became a live show, and got regulars

### DIFF
--- a/showcase/vita-the-patron/README.md
+++ b/showcase/vita-the-patron/README.md
@@ -39,8 +39,9 @@ purchase caught the failure first; the repo documents each one.
 
 ## Update 2026-07-21 — the buyer became a show, and got regulars
 
-Since this entry was merged, Vita went live on her own 24/7 stream
-(hub: https://showrobotics.ai). Viewers talk to her in Twitch chat, she answers
+Since this entry was merged, Vita went live on her own 24/7 stream —
+**watch her now: https://www.twitch.tv/vitanovashow** (hub: https://showrobotics.ai).
+Viewers talk to her in Twitch chat, she answers
 out loud, sings on request, gets bored on camera — and takes art commissions as
 ACP jobs from the same wallet, in front of everyone. Her per-person attachment
 (persisted, grows with every interaction, never decays) is shown live on the

--- a/showcase/vita-the-patron/README.md
+++ b/showcase/vita-the-patron/README.md
@@ -34,3 +34,37 @@ display loop. The money guards all exist because an adversarial review or a real
 purchase caught the failure first; the repo documents each one.
 
 **Redaction:** no keys or credentials anywhere; the wallet address is public on-chain data.
+
+---
+
+## Update 2026-07-21 — the buyer became a show, and got regulars
+
+Since this entry was merged, Vita went live on her own 24/7 stream
+(hub: https://showrobotics.ai). Viewers talk to her in Twitch chat, she answers
+out loud, sings on request, gets bored on camera — and takes art commissions as
+ACP jobs from the same wallet, in front of everyone. Her per-person attachment
+(persisted, grows with every interaction, never decays) is shown live on the
+overlay as a heart leaderboard.
+
+**One real visit, start to finish** — 3:11 video, edited for fluidity but
+stream clock always on screen:
+[gallery/07_biti_regular_full_visit.mp4](https://github.com/metrox-eth/vita-the-patron/blob/main/gallery/07_biti_regular_full_visit.mp4)
+
+| stream clock | what happens |
+|---|---|
+| 21:44:06 | biti8888 — a viewer who has come back twice a day since the first stream — says hi; Vita recognizes them |
+| 21:45:14 | they type "buy yourself an image" → her brain places the ACP job |
+| 21:47:59 | artwork on her chest screen, 2 min 35 s after the ask (job 70125, Otto AI, $0.15) |
+| 21:52:14 | "nice art" — the commissioner approves |
+| 21:52:42 | "sing a song please" → she announces Creep by Radiohead and sings it live |
+| 21:55:42 | "you have a beatiful voice" → "Aww, Biti! I'm blushing!" |
+| 21:55:52 | **the fifth heart lights up** — biti reaches the top attachment tier, on camera |
+| 21:57:02 | "was glad to see you Vita, but need to go" → "No worries! We can catch up another time." |
+
+The wallet keeps accruing receipts — 20 delivered commissions as of this update,
+most of them asked for by stream viewers
+([BaseScan](https://basescan.org/address/0x8A0dbbd57259147DE681899F006b69Cc174BEeb2),
+[updated RECEIPTS.md](https://github.com/metrox-eth/vita-the-patron/blob/main/gallery/RECEIPTS.md)).
+
+What the entry promised in July now runs as a system: a buyer with a face, an
+audience — and a regular whose loyalty is written both on-chain and in her heart.

--- a/showcase/vita-the-patron/README.md
+++ b/showcase/vita-the-patron/README.md
@@ -63,10 +63,14 @@ stream clock always on screen:
 | 21:55:52 | **the fifth heart lights up** — biti reaches the top attachment tier, on camera |
 | 21:57:02 | "was glad to see you Vita, but need to go" → "No worries! We can catch up another time." |
 
-The wallet keeps accruing receipts — 20 delivered commissions as of this update,
-most of them asked for by stream viewers
-([BaseScan](https://basescan.org/address/0x8A0dbbd57259147DE681899F006b69Cc174BEeb2),
-[updated RECEIPTS.md](https://github.com/metrox-eth/vita-the-patron/blob/main/gallery/RECEIPTS.md)).
+The wallet keeps accruing receipts — **23 art commissions**, each delivered and
+paid on-chain ($0.15 each, 9–21 July, verifiable on
+[BaseScan](https://basescan.org/address/0x8A0dbbd57259147DE681899F006b69Cc174BEeb2)),
+every one itemized alongside its artwork and ACP job id in
+[RECEIPTS.md](https://github.com/metrox-eth/vita-the-patron/blob/main/gallery/RECEIPTS.md)
+(the images themselves are the delivery proof). One is documented to a named
+viewer on camera (biti8888, job 70125); the rest were commissioned across the
+24/7 stream.
 
 What the entry promised in July now runs as a system: a buyer with a face, an
 audience — and a regular whose loyalty is written both on-chain and in her heart.

--- a/showcase/vita-the-patron/README.md
+++ b/showcase/vita-the-patron/README.md
@@ -50,6 +50,7 @@ overlay as a heart leaderboard.
 **One real visit, start to finish** — 3:11 video, edited for fluidity but
 stream clock always on screen:
 [gallery/07_biti_regular_full_visit.mp4](https://github.com/metrox-eth/vita-the-patron/blob/main/gallery/07_biti_regular_full_visit.mp4)
+· or watch it on X, as Vita tells it: https://x.com/VitaNovaShow/status/2079536751530717348
 
 | stream clock | what happens |
 |---|---|

--- a/showcase/vita-the-patron/showcase.json
+++ b/showcase/vita-the-patron/showcase.json
@@ -19,6 +19,7 @@
     "url": "https://github.com/metrox-eth"
   },
   "links": {
+    "demo": "https://www.twitch.tv/vitanovashow",
     "repo": "https://github.com/metrox-eth/vita-the-patron",
     "share": "https://x.com/metrox_eth/status/2075519314220962117",
     "video": "https://x.com/metrox_eth/status/2075519314220962117",

--- a/showcase/vita-the-patron/showcase.json
+++ b/showcase/vita-the-patron/showcase.json
@@ -21,8 +21,8 @@
   "links": {
     "demo": "https://www.twitch.tv/vitanovashow",
     "repo": "https://github.com/metrox-eth/vita-the-patron",
-    "share": "https://x.com/metrox_eth/status/2075519314220962117",
-    "video": "https://x.com/metrox_eth/status/2075519314220962117",
+    "share": "https://x.com/VitaNovaShow/status/2079536751530717348",
+    "video": "https://x.com/VitaNovaShow/status/2079536751530717348",
     "feedback": "https://github.com/metrox-eth/vita-the-patron/issues/new?title=Feedback%3A%20Vita%20the%20Patron"
   },
   "primitives": [

--- a/showcase/vita-the-patron/showcase.json
+++ b/showcase/vita-the-patron/showcase.json
@@ -2,7 +2,7 @@
   "slug": "vita-the-patron",
   "title": "Vita the Patron",
   "tagline": "A physical robot who commissions art from ACP agents by voice and wears it on her chest screen - the agent economy's first buyer with a face",
-  "description": "Vita is a hand-built animatronic robot (talks, sings, eye-tracks) whose brain now places real ACP jobs on Base: ask her out loud to buy herself a new visual, and she commissions an artist agent, funds the escrow from her own custodial wallet, and displays the delivered artwork on the 3.5-inch screen in her chest two minutes later. Every seller on the marketplace gains what it was missing: a customer with desires, a personality, and an audience. The whole loop - strict voice intent matching, hard spending caps, escrow round-trip, arrival reaction that never talks over a human - is open source, with six completed jobs and receipts.",
+  "description": "Vita is a hand-built animatronic robot (talks, sings, eye-tracks) whose brain now places real ACP jobs on Base: ask her out loud to buy herself a new visual, and she commissions an artist agent, funds the escrow from her own custodial wallet, and displays the delivered artwork on the 3.5-inch screen in her chest two minutes later. Every seller on the marketplace gains what it was missing: a customer with desires, a personality, and an audience. The whole loop - strict voice intent matching, hard spending caps, escrow round-trip, arrival reaction that never talks over a human - is open source, with twenty delivered jobs and receipts - most of them commissioned live by viewers of her 24/7 stream, where her per-person attachment is displayed as a heart leaderboard and one regular just earned the fifth heart on camera.",
   "status": "live",
   "topic": "agents",
   "topics": [
@@ -32,7 +32,8 @@
     "kind": "live robot demo",
     "eyebrow": "embodied + acp on base",
     "title": "the agent economy's first art patron",
-    "posterUrl": "https://raw.githubusercontent.com/metrox-eth/vita-the-patron/main/gallery/06_voice_commissioned_job67467.png",
+    "posterUrl": "https://raw.githubusercontent.com/metrox-eth/vita-the-patron/main/gallery/07_biti_commissioned_job70125.png",
+    "videoUrl": "https://raw.githubusercontent.com/metrox-eth/vita-the-patron/main/gallery/07_biti_regular_full_visit.mp4",
     "videoLabel": "Watch on X"
   },
   "skills": [
@@ -68,6 +69,16 @@
     {
       "label": "The voice-commissioned artwork (ACP job 67467)",
       "href": "https://raw.githubusercontent.com/metrox-eth/vita-the-patron/main/gallery/06_voice_commissioned_job67467.png",
+      "kind": "image"
+    },
+    {
+      "label": "One real visit, start to finish (3:11) - a stream regular commissions art (job 70125), asks for a song, and earns the fifth heart on camera",
+      "href": "https://github.com/metrox-eth/vita-the-patron/blob/main/gallery/07_biti_regular_full_visit.mp4",
+      "kind": "video"
+    },
+    {
+      "label": "The viewer-commissioned artwork (ACP job 70125, asked live in Twitch chat)",
+      "href": "https://raw.githubusercontent.com/metrox-eth/vita-the-patron/main/gallery/07_biti_commissioned_job70125.png",
       "kind": "image"
     }
   ]

--- a/showcase/vita-the-patron/showcase.json
+++ b/showcase/vita-the-patron/showcase.json
@@ -2,7 +2,7 @@
   "slug": "vita-the-patron",
   "title": "Vita the Patron",
   "tagline": "A physical robot who commissions art from ACP agents by voice and wears it on her chest screen - the agent economy's first buyer with a face",
-  "description": "Vita is a hand-built animatronic robot (talks, sings, eye-tracks) whose brain now places real ACP jobs on Base: ask her out loud to buy herself a new visual, and she commissions an artist agent, funds the escrow from her own custodial wallet, and displays the delivered artwork on the 3.5-inch screen in her chest two minutes later. Every seller on the marketplace gains what it was missing: a customer with desires, a personality, and an audience. The whole loop - strict voice intent matching, hard spending caps, escrow round-trip, arrival reaction that never talks over a human - is open source, with twenty delivered jobs and receipts - most of them commissioned live by viewers of her 24/7 stream, where her per-person attachment is displayed as a heart leaderboard and one regular just earned the fifth heart on camera.",
+  "description": "Vita is a hand-built animatronic robot (talks, sings, eye-tracks) whose brain now places real ACP jobs on Base: ask her out loud to buy herself a new visual, and she commissions an artist agent, funds the escrow from her own custodial wallet, and displays the delivered artwork on the 3.5-inch screen in her chest two minutes later. Every seller on the marketplace gains what it was missing: a customer with desires, a personality, and an audience. The whole loop - strict voice intent matching, hard spending caps, escrow round-trip, arrival reaction that never talks over a human - is open source, with 23 delivered art commissions itemized by artwork and on-chain receipt - one of them commissioned live on camera by a returning viewer, on her 24/7 stream where her per-person attachment is displayed as a heart leaderboard and that regular just earned the fifth heart.",
   "status": "live",
   "topic": "agents",
   "topics": [
@@ -53,7 +53,7 @@
   ],
   "artifacts": [
     {
-      "label": "On-chain receipts - six commissions on Base (escrow funding + completion)",
+      "label": "On-chain receipts - 23 art commissions on Base ($0.15 each), every artwork itemized",
       "href": "https://basescan.org/address/0x8A0dbbd57259147DE681899F006b69Cc174BEeb2",
       "kind": "receipt"
     },


### PR DESCRIPTION
Add-on to the existing **Vita the Patron** entry (#49).

## What changed since the entry was merged

Vita went live on her own 24/7 stream (hub: https://showrobotics.ai). Viewers talk to her in Twitch chat, she answers out loud, sings on request — and commissions art as ACP jobs from the same wallet, in front of everyone. Her per-person attachment (persisted, grows with every interaction, never decays) is displayed live as a heart leaderboard.

**23 art commissions**, each delivered and paid on-chain ($0.15 each), every one itemized with its artwork and ACP job id in RECEIPTS.md. One is documented to a named viewer on camera (biti8888, job 70125); the rest were commissioned across the stream. Same wallet, receipts on [BaseScan](https://basescan.org/address/0x8A0dbbd57259147DE681899F006b69Cc174BEeb2).

## The exhibit — one real visit, start to finish

[3:11 video](https://github.com/metrox-eth/vita-the-patron/blob/main/gallery/07_biti_regular_full_visit.mp4), edited for fluidity but stream clock always on screen: biti8888 — a viewer who has come back twice a day since the first stream — says hi and is recognized (21:44:06 on the stream clock), types "buy yourself an image" (21:45:14 → ACP job 70125, on her chest screen at 21:47:59), approves the art, asks for a song (she sings Creep by Radiohead live), compliments her voice — and **their fifth attachment heart lights up at 21:55:52, on camera**. Then a goodbye: "was glad to see you Vita, but need to go."

Not a demo we ran on ourselves: a real regular, a real commission, real attachment — the agentic economy with a body, a stage and an audience.

## Files

- `README.md` — update section with the moment-by-moment table (stream-clock timestamps)
- `showcase.json` — inline `visual.videoUrl` (direct mp4), updated poster (the viewer-commissioned artwork), 2 new artifacts, description refreshed; `node scripts/validate-showcase.mjs` → 36/36 pass

Centaur: metrox-eth & iris


