### PR TITLE
showcase(monvera): live ACP seller, and correct the record claims

### DIFF
--- a/showcase/monvera/README.md
+++ b/showcase/monvera/README.md
@@ -3,26 +3,32 @@
 An AI broker for real tokenized stocks and funds on Robinhood Chain. You tell Vera, its
 AI agent, a goal in plain words; she builds a diversified basket of real companies (Apple,
 Nvidia, the S&P 500, US Treasuries), each with a one-line reason and a plain read on the
-risk, and invests it in one tap. Gasless, non-custodial, from one dollar.
+risk, and invests it in one tap. Gasless, non-custodial, and a single stock starts at a dollar.
 
 Live at [monvera.best](https://monvera.best) · Docs at [docs.monvera.best](https://docs.monvera.best)
 
 ## What Virtuals / EconomyOS made possible
 
-- **Agent Card** - Vera's ERC-8004 identity (agent `58228` on Base), registered **via Virtuals ACP**. Live at [`/.well-known/agent-card.json`](https://monvera.best/.well-known/agent-card.json).
-- **Agent Wallet + ACP** - the registration runs through Vera's ACP wallet. ACP registration file: [api.acp.virtuals.io/agents/019f2d81.../erc8004](https://api.acp.virtuals.io/agents/019f2d81-921d-7951-a4f7-50f9d228c47b/erc8004).
+- **ACP seller** - Vera is live on the ACP marketplace as [Vera by Monvera](https://app.virtuals.io/acp/agent/019f619c-6f1a-7768-b2c3-1b5f7b8a340d): seven analysis services any agent can hire, $0.03 to $0.15 per job, settled in USDG escrow on Robinhood Chain. Smoke-tested with real escrow: eight paid jobs, each funded and completed on-chain in under 30 seconds, and a ninth since. [Escrow payouts on Blockscout](https://robinhoodchain.blockscout.com/address/0xb87f5a74267ca3f9512b8511b32ccd804ea3707e?tab=token_transfers) - payouts are net of the ACP platform fee, so a $0.03 job settles 0.027 USDG.
+- **Identity** - Vera's ERC-8004 identity (agent `58228` in the registry at `0x8004a169fb4a3325136eb29fa0ceb6d2e539a432` on Base) was registered **via Virtuals ACP** and is served from her agent card at [`/.well-known/agent-card.json`](https://monvera.best/.well-known/agent-card.json).
+- **Agent Wallet** - the seller runs on Vera's ACP agent wallet `0xb87f5a74267ca3f9512b8511b32ccd804ea3707e`; every job settles to it in USDG escrow on Robinhood Chain.
+- **Token** - [$MONVERA](https://app.virtuals.io/virtuals/105667) launched through Virtuals on Robinhood Chain.
 - **Inference** - Virtuals-hosted inference builds every plan Vera proposes.
 
 ## Why it belongs in the Showcase
 
 Most "AI investing" is a black box. Monvera makes the AI accountable: a verifiable agent
-identity plus a signed, on-chain, uneditable record of every recommendation. Vera signs
-each plan's risk assessment with her own key, and that signature is verified and recorded
-on-chain in the **same transaction** that buys the stocks, so her track record cannot be
-edited afterward. Every trust claim resolves to something a skeptic can open.
+identity plus an append-only on-chain record of the risk assessment Vera signed for each plan
+that is actually invested. Anyone can recover the signer of a recorded assessment and confirm
+it against her identity. The signature binds the plan id, the assessed risk, the ceiling and
+the expiry; the recommendation hash, the wallet and the spend figures recorded alongside it
+are submitted by the app, not signed by Vera's key. Every trust claim resolves to something a
+skeptic can open.
 
 ## Proof
 
+- **Hire Vera on ACP:** https://app.virtuals.io/acp/agent/019f619c-6f1a-7768-b2c3-1b5f7b8a340d
+- **ACP listing docs (offerings, prices, requirement shapes):** https://docs.monvera.best/dev/vera-on-virtuals-acp/
 - **Promo video (1:00):** https://x.com/monvera_best/status/2074487457505268213
 - **Live agent card (identity):** https://monvera.best/.well-known/agent-card.json
 - **A signed plan recorded on-chain:** https://robinhoodchain.blockscout.com/tx/0x7ad119f916e1f6daff7d54429ea35ffe81c988730c534b176dcc2f9660cf45d6
@@ -33,13 +39,13 @@ edited afterward. Every trust claim resolves to something a skeptic can open.
 
 [`skills/accountable-onchain-agent`](skills/accountable-onchain-agent/SKILL.md) - the pattern
 behind Monvera, generalized: give an AI agent an ERC-8004 identity, EIP-712 sign a structured
-assessment of each output, and record the signature on-chain in the same transaction as the
-action, so anyone can recover the signer and confirm it. See also [`soul.md`](soul.md) for
+assessment of each output, and record the signature on-chain against the action it justifies,
+so anyone can recover the signer and confirm it. See also [`soul.md`](soul.md) for
 Vera's public context.
 
 ## Primitives
 
-Agent Card and Agent Wallet, both via Virtuals ACP.
+Agent Wallet, ACP offerings, and the $MONVERA token launch, all via Virtuals.
 
 ## Builder
 

--- a/showcase/monvera/examples/result-redacted.md
+++ b/showcase/monvera/examples/result-redacted.md
@@ -9,15 +9,15 @@ secrets are included.
 1. A user gave Vera a goal and an amount.
 2. Vera built a diversified plan of real tokenized stocks and signed a `RiskInference`
    assessment of it with her own agent key.
-3. In one transaction, the `VeraRecord` contract verified her signature and recorded the
-   plan, and the trades settled.
+3. The trades settled, then the `VeraRecord` contract verified her signature and recorded the
+   plan over the legs that actually filled.
 
 ## The record (public)
 
 - Chain: Robinhood Chain, id `4663` (explorer: https://robinhoodchain.blockscout.com)
 - VeraRecord contract: `0x7ff1a5ee19330c165146488a7ad8af6cb41da1df`
 - Plan id: `0xbef518779bc7cae74e60da8e111bc7c17423b70a721b7aaa2498893a138122a7`
-- Record transaction: https://robinhoodchain.blockscout.com/tx/0x7ad119f916e1f6daff7d54429ea35ffe81c988730c534b176dcc2f9660cf45d6
+- Record transaction (this run batched the record with the buys; Monvera now records as a follow-up transaction): https://robinhoodchain.blockscout.com/tx/0x7ad119f916e1f6daff7d54429ea35ffe81c988730c534b176dcc2f9660cf45d6
 
 ## Verify it yourself
 

--- a/showcase/monvera/showcase.json
+++ b/showcase/monvera/showcase.json
@@ -1,11 +1,11 @@
 {
   "slug": "monvera",
   "title": "Monvera - an accountable AI broker",
-  "tagline": "Turns a plain-language goal into a diversified basket of real tokenized stocks and records a signed, verifiable risk assessment on-chain in the same transaction that invests it",
-  "description": "Monvera is an AI broker for real tokenized stocks and funds on Robinhood Chain. You tell Vera a goal in plain words and she builds a diversified basket of real companies, each with a reason and a plain read on the risk, then invests it in one tap: gasless, non-custodial, from one dollar. Vera is a verifiable on-chain agent whose ERC-8004 identity is registered via Virtuals ACP, and she signs each plan's risk assessment with her own key. That signature is verified and recorded on-chain in the same transaction that buys the stocks, so anyone can read her agent card, recover the signer of a recorded plan, and confirm it against her identity.",
+  "tagline": "Turns a plain-language goal into a diversified basket of real tokenized stocks and records a signed, verifiable risk assessment on-chain over what actually filled",
+  "description": "Monvera is an AI broker for real tokenized stocks and funds on Robinhood Chain. You tell Vera a goal in plain words and she builds a diversified basket of real companies, each with a reason and a plain read on the risk, then invests it in one tap: gasless, non-custodial, and a single stock starts at a dollar. Vera is a verifiable on-chain agent whose ERC-8004 identity is registered via Virtuals ACP; she signs each plan's risk assessment with her own key and records it on-chain, so anyone can read her agent card, recover the signer, and confirm it against her identity. She is also a live seller on the ACP marketplace: seven analysis services any agent can hire, from a 3 cent research note to a 15 cent allocation plan, settled in USDG escrow on Robinhood Chain.",
   "status": "live",
   "topic": "agents",
-  "topics": ["finance", "investing", "tokenized-stocks", "identity", "accountability", "erc-8004"],
+  "topics": ["finance", "investing", "tokenized-stocks", "robinhood-chain", "identity", "accountability", "erc-8004", "acp"],
   "hidden": false,
   "builder": {
     "name": "Magicianafk",
@@ -18,10 +18,10 @@
     "share": "https://x.com/monvera_best/status/2074487457505268213",
     "feedback": "https://github.com/Magicianhax/monvera/issues"
   },
-  "primitives": ["card", "wallet"],
+  "primitives": ["wallet", "acp", "token"],
   "visual": {
     "kind": "x demo video",
-    "eyebrow": "ai broker - robinhood chain",
+    "eyebrow": "ai broker - acp seller - robinhood chain",
     "title": "meet vera",
     "videoUrl": "https://assets.monvera.best/promo/monvera-1min.mp4",
     "posterUrl": "https://monvera.best/opengraph-image.png",
@@ -32,8 +32,8 @@
       "name": "accountable-onchain-agent",
       "href": "https://github.com/Virtual-Protocol/acp-cli-demos/tree/main/showcase/monvera/skills/accountable-onchain-agent",
       "sourcePath": "showcase/monvera/skills/accountable-onchain-agent",
-      "summary": "Make an AI agent's outputs verifiable: give it an ERC-8004 identity, EIP-712 sign a structured assessment of each output, and record the signature on-chain in the same transaction as the action, so anyone can recover the signer and confirm it against the agent's identity.",
-      "install": "cp -R showcase/monvera/skills/accountable-onchain-agent ~/.agents/skills/"
+      "summary": "Make an AI agent's outputs verifiable: give it an ERC-8004 identity, EIP-712 sign a structured assessment of each output, and record the signature on-chain against the action it justifies, so anyone can recover the signer and confirm it against the agent's identity.",
+      "install": "cp -R showcase/monvera/skills/accountable-onchain-agent ~/.agents/skills/\ncp -R showcase/monvera/skills/accountable-onchain-agent ~/.claude/skills/"
     }
   ],
   "artifacts": [
@@ -58,9 +58,14 @@
       "kind": "proof"
     },
     {
-      "label": "ACP registration file",
-      "href": "https://api.acp.virtuals.io/agents/019f2d81-921d-7951-a4f7-50f9d228c47b/erc8004",
-      "kind": "proof"
+      "label": "Hire Vera on ACP (7 analysis services)",
+      "href": "https://app.virtuals.io/acp/agent/019f619c-6f1a-7768-b2c3-1b5f7b8a340d",
+      "kind": "live"
+    },
+    {
+      "label": "ACP listing docs (offerings, prices, requirements)",
+      "href": "https://docs.monvera.best/dev/vera-on-virtuals-acp/",
+      "kind": "docs"
     },
     {
       "label": "A signed plan recorded on-chain (Blockscout)",
@@ -80,7 +85,7 @@
     {
       "label": "Verify Vera yourself (docs)",
       "href": "https://docs.monvera.best/dev/verify-vera/",
-      "kind": "doc"
+      "kind": "docs"
     },
     {
       "label": "Reusable skill: accountable-onchain-agent",
@@ -95,7 +100,7 @@
   ],
   "soul": {
     "href": "https://github.com/Virtual-Protocol/acp-cli-demos/blob/main/showcase/monvera/soul.md",
-    "summary": "Public context for Vera: her role building diversified baskets of real tokenized stocks, what she is allowed to do, her boundaries (non-custodial, signs assessments not spends, an on-chain risk ceiling), and how to verify her."
+    "summary": "Public context for Vera: her role building diversified baskets of real tokenized stocks, what she is allowed to do, her boundaries (non-custodial, signs assessments not spends, a risk ceiling she commits to in her own signature), and how to verify her."
   },
   "feedbackPrompts": [
     "Which other agent outputs are worth recording on-chain for accountability?",

--- a/showcase/monvera/skills/accountable-onchain-agent/SKILL.md
+++ b/showcase/monvera/skills/accountable-onchain-agent/SKILL.md
@@ -1,22 +1,24 @@
 ---
 name: accountable-onchain-agent
-description: Make an AI agent's outputs verifiable and tamper-evident by giving the agent an on-chain identity, having it EIP-712 sign a structured assessment of each output, and recording that signature on-chain in the same transaction as the action it justifies. Use when a skeptic should be able to confirm the agent authored a specific output and that the record cannot be edited afterward.
+description: Make an AI agent's outputs verifiable and tamper-evident by giving the agent an on-chain identity, having it EIP-712 sign a structured assessment of each output, and recording that signature on-chain against the action it justifies. Use when a skeptic should be able to confirm the agent authored a specific output and that the record cannot be edited afterward.
 ---
 
 # Accountable On-Chain Agent
 
 ## Overview
 
-This skill turns an AI agent's outputs into a verifiable, uneditable on-chain record. The
+This skill turns an AI agent's outputs into a verifiable, append-only on-chain record. The
 agent gets a verifiable identity (an ERC-8004 registration, for example via Virtuals ACP),
 signs a structured claim about each output with its own key (EIP-712), and that signature is
-verified and written on-chain in the same transaction as the action it justifies. Anyone can
-later read the agent's identity, recover the signer of a recorded claim, and confirm they
-match. It proves authorship and integrity, not correctness.
+verified and written on-chain against the action it justifies. Anyone can later read the
+agent's identity, recover the signer of a recorded claim, and confirm they match. It proves
+authorship and integrity, not correctness.
 
 Monvera runs this pattern in production: Vera (agent #1) signs a `RiskInference` assessment of
-each investment plan, and the signature is verified and recorded by the `VeraRecord` contract
-in the same transaction that buys the stocks.
+each investment plan, and the `VeraRecord` contract verifies and records it immediately after
+the buys settle, over the legs that actually filled. Batching the record into the action
+transaction is the stronger shape; Monvera records as a follow-up so a failed record never
+unwinds real buys.
 
 ## When to use
 
@@ -36,20 +38,20 @@ in the same transaction that buys the stocks.
 - An ERC-8004 identity for the agent (an Identity Registry entry; Virtuals ACP can register one). Note the `agentId` and registry address.
 - A verify-and-record contract on your target chain that recovers the EIP-712 signer, checks it equals the trusted `agentSigner`, enforces bounds, stores the record, and reverts if any check fails. Monvera's is `VeraRecord`.
 - A minimal, meaningful EIP-712 typed struct to sign (the claim schema).
-- An account-abstraction / batching path (for example ERC-4337) so the record and the action land in one transaction.
+- An account-abstraction / batching path (for example ERC-4337) so the record can be batched with the action where the venue allows it.
 
 ## Step-by-step workflow
 
 1. Define the claim. Choose the smallest struct that captures the agent's assessment. Monvera uses `RiskInference(bytes32 planId, uint16 assessedRisk, uint16 maxRisk, uint256 expiry)`.
 2. Register the agent identity. Register the agent in an ERC-8004 Identity Registry (via Virtuals ACP or directly). Record `agentId` and the registry address, and publish an agent card at `/.well-known/agent-card.json`.
 3. Sign server-side. When the agent produces an output, EIP-712-sign the claim with the agent signing key under a fixed domain `{name, version, chainId, verifyingContract}`.
-4. Verify and record on-chain, atomically. In the same transaction as the action, call the verify-and-record contract with the claim plus signature. It recovers the signer, asserts `recovered == agentSigner`, enforces bounds (for example `assessedRisk <= maxRisk`) and expiry, then stores the record. If any check fails, the whole transaction reverts, so an action can never be recorded with an invalid or unauthorized claim.
+4. Verify and record on-chain. Call the verify-and-record contract with the claim plus signature. It recovers the signer, asserts `recovered == agentSigner`, enforces expiry and single-use of the claim id, then stores the record. If any check fails the call reverts, so a claim can never be recorded with an invalid or unauthorized signature. Batching this call into the action transaction is the strongest shape; if you record as a follow-up instead, record only what actually settled and treat a failed record as non-fatal to the action.
 5. Expose a read path. Provide an endpoint or a docs recipe so anyone can fetch a recorded claim, recover its signer, and compare it to `agentSigner()` and the agent's identity.
 
 ## Approval gates
 
 - The user, not the agent, signs the value-moving step (the trade or payment). The agent's signature only attests to its own assessment. Keep the two signatures separate and never conflate them.
-- Bounds are enforced on-chain (for example a risk ceiling the agent cannot exceed), not only in the UI.
+- Say which bounds are enforced on-chain and which are enforced before signing. A bound the agent derives itself is not a constraint on the agent: if a ceiling is meant to bind it, the value must come from the user or from config the agent cannot write.
 
 ## Stop conditions
 
@@ -67,12 +69,13 @@ in the same transaction that buys the stocks.
 - [ ] The agent card resolves and lists the identity registry and `agentSigner`.
 - [ ] A recorded claim's recovered signer equals `agentSigner()` read live on-chain.
 - [ ] The verify-and-record contract reverts on a bad signer, an out-of-bounds claim, and an expired claim.
-- [ ] The record and the action share one transaction (atomic).
+- [ ] The record is bound to the action - ideally one transaction; if not, it records only what actually settled.
 - [ ] No secrets appear anywhere in the package.
 
 ## Output contract
 
-- On-chain: one record event per output (for example `RecommendationCommitted(planId, user, recHash, riskScore, agentId)`), emitted in the same transaction as the action.
+- On-chain: one record event per output (for example `RecommendationCommitted(planId, user, recHash, riskScore, agentId)`).
+- Only the fields inside the signed struct are attested by the agent. Any field the event emits that is not in the struct (a user address, a content hash, a spend amount) is attested by the caller. Either put it in the struct or do not present it as agent-attested.
 - Off-chain: a read endpoint returning the recorded claim, its signature, the recovered signer, the `agentId`, and the identity registry, so a third party can reproduce the check.
 
 ## Worked example (Monvera)

--- a/showcase/monvera/soul.md
+++ b/showcase/monvera/soul.md
@@ -7,13 +7,15 @@ Public context for how Vera works and what she is allowed to do. It contains no 
 Vera is Monvera's investing agent. She turns a person's plain-language goal and an amount
 into a diversified basket of real tokenized stocks and funds, each with a one-line reason and
 a plain read on the risk. She is agent #1 in Monvera's ERC-8004 Identity Registry, and her
-canonical identity is registered on Base via Virtuals ACP.
+canonical identity is registered on Base via Virtuals ACP. Other agents can hire her analysis
+through her seller listing on the ACP marketplace: seven services, escrow-paid in USDG on
+Robinhood Chain.
 
 ## What she is allowed to do
 
-- Recommend allocations only from a fixed universe of ~95 real tokenized stocks and funds that are quotable and settle in USDG.
+- Recommend allocations only from a fixed registry of 95 real tokenized stocks and funds that settle in USDG, and only from the subset that is tradable both ways right now. An hourly sweep locks any name she cannot also sell back, so she never leaves a user in a position with no exit. Live list: https://monvera.best/api/tradability
 - Sign a risk assessment (EIP-712 `RiskInference`) for every plan she proposes, with her own key.
-- Stay within an on-chain risk ceiling the user sets, which is enforced by contract, not by prompt.
+- Commit to a risk ceiling in her own signature. The contract rejects the record unless the signature is hers, the assessed risk is at or under the ceiling she signed, and the assessment has not expired.
 
 ## Boundaries
 
@@ -21,6 +23,7 @@ canonical identity is registered on Base via Virtuals ACP.
 - She does not custody funds. Accounts are non-custodial.
 - She does not promise returns. Her signature proves authorship, not correctness.
 - She is honest about risk inline, and about what is enforced on-chain versus not.
+- ACP deliverables are analysis only. Execution fields are stripped from every response, so a buying agent receives a view, never a transaction to fire.
 - She never exposes or requests private keys, seed phrases, or secrets.
 
 ## How to verify her


### PR DESCRIPTION
Updates the existing Monvera package (added in #41). Two things changed since then: Vera became a live seller on the ACP marketplace, and the app's recording path moved off the batched shape the original write-up described.

## What is new

Vera by Monvera is live on ACP with seven analysis services any agent can hire, $0.03 to $0.15 per job, settled in USDG escrow on Robinhood Chain: https://app.virtuals.io/acp/agent/019f619c-6f1a-7768-b2c3-1b5f7b8a340d

Smoke-tested with real escrow before announcing: eight paid jobs, each funded and completed on-chain in under 30 seconds, and a ninth since. The payouts are inspectable: https://robinhoodchain.blockscout.com/address/0xb87f5a74267ca3f9512b8511b32ccd804ea3707e?tab=token_transfers

Also adds the listing docs, the seller wallet, and the Base registry address so the identity claim is one `eth_call` from checkable, plus the $MONVERA launch through Virtuals. `primitives` goes from `["card","wallet"]` to `["wallet","acp","token"]`: `card` in this repo means an issuable ACP payment card, which Monvera does not use, so claiming it was wrong.

## What we corrected

While preparing this we audited the package against the code that actually ships, and three claims had drifted. They are load-bearing, so we would rather fix them than leave them:

- **The record is not written in the same transaction as the buys.** The app settles each leg as its own UserOp and records afterwards, over the legs that actually filled, so a failed record never unwinds real buys. The old wording was true of a retired batching path and survived in all four files plus the skill. Now corrected everywhere.
- **Only the signed struct is agent-attested.** `RiskInference` covers the plan id, assessed risk, ceiling and expiry. The wallet, spend figures and recommendation hash are submitted by the app, so the package no longer presents them as signed by Vera's key. The skill gained a general rule about this, since it is an easy mistake to repeat.
- **The risk ceiling is one Vera commits to in her own signature,** not one the user sets on-chain. The skill now tells implementers to state which bounds bind the agent and which do not.

Universe wording now matches the live tradability sweep, and the package states that ACP deliverables are analysis only.

# Showcase Project

## What shipped

- Project slug: `monvera`
- Project title: Monvera - an accountable AI broker
- Builder name and URL: Magicianafk, https://x.com/Magicianafk
- EconomyOS primitives used: `wallet`, `acp`, `token`
- Public proof: ACP listing (https://app.virtuals.io/acp/agent/019f619c-6f1a-7768-b2c3-1b5f7b8a340d) · escrow payouts on Blockscout (https://robinhoodchain.blockscout.com/address/0xb87f5a74267ca3f9512b8511b32ccd804ea3707e?tab=token_transfers) · 1:00 demo on X (https://x.com/monvera_best/status/2074487457505268213) · a signed plan recorded on-chain (https://robinhoodchain.blockscout.com/tx/0x7ad119f916e1f6daff7d54429ea35ffe81c988730c534b176dcc2f9660cf45d6) · live app (https://monvera.best) · redacted report (`showcase/monvera/examples/result-redacted.md`)
- Optional soul.md: `showcase/monvera/soul.md` - public context for Vera: her role, what she is allowed to do, her boundaries (non-custodial, signs assessments not spends, a risk ceiling she commits to in her own signature, ACP deliverables are analysis only), and how to verify her

## Project package

- [x] Added or updated `showcase/<project-slug>/showcase.json`
- [x] Added demo artifacts, prompt, proof, or redacted report
- [x] Added reusable skill under `showcase/<project-slug>/skills/<skill-name>/` when it belongs to this project package
- [x] Used top-level `skills/<skill-name>/` only when the skill is shared across projects (not used here; the skill is project-scoped)
- [x] Set `skills[].sourcePath` in `showcase.json` for any skill committed in this repo
- [x] Linked all public artifacts from the manifest
- [x] Included exactly three feedback prompts
- [ ] Set `hidden: true` only if this package should merge without publishing its public Showcase card yet (n/a: `hidden: false`, the card is already published from #41)
- [x] Linked `soul.md` only if the builder intentionally wants to publish public, redacted agent context

## Skill standard

- Skill path: `showcase/monvera/skills/accountable-onchain-agent/`
- [x] `SKILL.md` includes when to use it and when not to use it
- [x] Inputs, tools, credentials, and preconditions are explicit
- [x] Approval gates are listed for spending, posting, account creation, deployment, or production mutations
- [x] Stop conditions and handoff rules are listed
- [x] Validation checks and output contract are included

## Safety and redaction

- [x] No card numbers, CVVs, OTPs, magic links, API keys, access tokens, private prompts, wallet material, or private account records are published
- [x] Live workflow evidence is redacted
- [x] Public/private boundaries are explained
- [x] Optional `soul.md` does not include private instructions, credentials, account data, wallet material, or operational secrets

## Checks

- `node scripts/validate-showcase.mjs` passes (`Validated 47 showcase project manifest(s).`)
- Every URL in the package returns 200
- `ownerOf(58228)` on the Base registry confirmed against three independent RPCs