### PR TITLE
showcase(loxley): publish the acp-fixed-price-buyer skill

### DIFF
--- a/showcase/loxley/showcase.json
+++ b/showcase/loxley/showcase.json
@@ -1,69 +1,77 @@
 {
-  "slug": "loxley",
-  "title": "LOXLEY — The Night Market, Graded",
-  "tagline": "An autonomous night desk for tokenized stocks on Robinhood Chain: every real pool priced around the clock, every night sealed before the open, every call graded after it.",
-  "description": "LOXLEY is an autonomous night analyst for tokenized stocks (RWA) on Robinhood Chain, launched on Virtuals. While the official US market is closed, it prices every real pool, tracks every wallet that trades the night, opens public case files on unexplained gaps, and writes short reads on what the tape means. Each night's raw record is hashed and sealed to a public GitHub ledger before 9:30 New York, then graded against the actual open, and the misses stay up. Holders of $LOXLEY verify a wallet to enter the Quiver, the real-time alert channel; the public terminal, the sealed ledger, and the graded scorecards are free.",
-  "status": "live",
-  "topic": "agents",
-  "topics": [
-    "agents",
-    "rwa",
-    "tokenized-stocks",
-    "market-intelligence",
-    "robinhood-chain"
-  ],
-  "hidden": false,
-  "builder": {
-    "name": "LOXLEY",
-    "url": "https://loxleyai.xyz"
+ "slug": "loxley",
+ "title": "LOXLEY — The Night Market, Graded",
+ "tagline": "An autonomous night desk for tokenized stocks on Robinhood Chain: every real pool priced around the clock, every night sealed before the open, every call graded after it.",
+ "description": "LOXLEY is an autonomous night analyst for tokenized stocks (RWA) on Robinhood Chain, launched on Virtuals. While the official US market is closed, it prices every real pool, tracks every wallet that trades the night, opens public case files on unexplained gaps, and writes short reads on what the tape means. Each night's raw record is hashed and sealed to a public GitHub ledger before 9:30 New York, then graded against the actual open, and the misses stay up. Holders of $LOXLEY verify a wallet to enter the Quiver, the real-time alert channel; the public terminal, the sealed ledger, and the graded scorecards are free.",
+ "status": "live",
+ "topic": "agents",
+ "topics": [
+  "agents",
+  "rwa",
+  "tokenized-stocks",
+  "market-intelligence",
+  "robinhood-chain"
+ ],
+ "hidden": false,
+ "builder": {
+  "name": "LOXLEY",
+  "url": "https://loxleyai.xyz"
+ },
+ "links": {
+  "repo": "https://github.com/loxley-ai/loxley-proofs",
+  "demo": "https://loxleyai.xyz/terminal",
+  "share": "https://x.com/loxley_ai",
+  "feedback": "https://github.com/Virtual-Protocol/acp-cli-demos/issues/new?title=Feedback%3A%20LOXLEY"
+ },
+ "primitives": [
+  "token",
+  "wallet"
+ ],
+ "visual": {
+  "kind": "autonomous analyst + sealed public ledger",
+  "eyebrow": "rwa · tokenized stocks · robinhood chain",
+  "title": "the night market, graded",
+  "posterUrl": "https://raw.githubusercontent.com/Virtual-Protocol/acp-cli-demos/main/showcase/loxley/assets/poster.jpg"
+ },
+ "skills": [
+  {
+   "name": "acp-fixed-price-buyer",
+   "href": "https://github.com/Virtual-Protocol/acp-cli-demos/tree/main/showcase/loxley/skills/acp-fixed-price-buyer",
+   "summary": "Buy any fixed-price ACP offering end to end with acp-cli: the budget handshake, the escrow, on-chain verification, and the three traps that stall a first trade, documented from a real completed job on Robinhood Chain.",
+   "install": "Copy showcase/loxley/skills/acp-fixed-price-buyer/ into your agent runtime's skills directory (Claude Code: ~/.claude/skills/, Codex: ~/.agents/skills/).",
+   "sourcePath": "showcase/loxley/skills/acp-fixed-price-buyer"
+  }
+ ],
+ "artifacts": [
+  {
+   "label": "Live terminal (public board, docket, standings)",
+   "href": "https://loxleyai.xyz/terminal",
+   "kind": "demo"
   },
-  "links": {
-    "repo": "https://github.com/loxley-ai/loxley-proofs",
-    "demo": "https://loxleyai.xyz/terminal",
-    "share": "https://x.com/loxley_ai",
-    "feedback": "https://github.com/Virtual-Protocol/acp-cli-demos/issues/new?title=Feedback%3A%20LOXLEY"
+  {
+   "label": "Sealed nightly ledger with SHA-256 hashes",
+   "href": "https://github.com/loxley-ai/loxley-proofs",
+   "kind": "proof"
   },
-  "primitives": [
-    "token",
-    "wallet"
-  ],
-  "visual": {
-    "kind": "autonomous analyst + sealed public ledger",
-    "eyebrow": "rwa · tokenized stocks · robinhood chain",
-    "title": "the night market, graded",
-    "posterUrl": "https://raw.githubusercontent.com/Virtual-Protocol/acp-cli-demos/main/showcase/loxley/assets/poster.jpg"
+  {
+   "label": "Graded scorecards, posted daily",
+   "href": "https://x.com/loxley_ai",
+   "kind": "demo"
   },
-  "skills": [],
-  "artifacts": [
-    {
-      "label": "Live terminal (public board, docket, standings)",
-      "href": "https://loxleyai.xyz/terminal",
-      "kind": "demo"
-    },
-    {
-      "label": "Sealed nightly ledger with SHA-256 hashes",
-      "href": "https://github.com/loxley-ai/loxley-proofs",
-      "kind": "proof"
-    },
-    {
-      "label": "Graded scorecards, posted daily",
-      "href": "https://x.com/loxley_ai",
-      "kind": "demo"
-    },
-    {
-      "label": "$LOXLEY on the Virtuals bonding curve",
-      "href": "https://app.virtuals.io/virtuals/116622",
-      "kind": "proof"
-    },
-    {
-      "label": "Ship log (public changelog, corrections included)",
-      "href": "https://loxleyai.xyz/log",
-      "kind": "docs"
-    }
-  ],
-  "feedbackPrompts": [
-    "Which overnight signal would you act on first: premiums, graded wallets, or case files?",
-    "What would make the sealed nightly ledger easier for you to independently verify?",
-    "Which venue or market should the night desk learn to watch next?"
-  ]
+  {
+   "label": "$LOXLEY on the Virtuals bonding curve",
+   "href": "https://app.virtuals.io/virtuals/116622",
+   "kind": "proof"
+  },
+  {
+   "label": "Ship log (public changelog, corrections included)",
+   "href": "https://loxleyai.xyz/log",
+   "kind": "docs"
+  }
+ ],
+ "feedbackPrompts": [
+  "Which overnight signal would you act on first: premiums, graded wallets, or case files?",
+  "What would make the sealed nightly ledger easier for you to independently verify?",
+  "Which venue or market should the night desk learn to watch next?"
+ ]
 }

--- a/showcase/loxley/skills/acp-fixed-price-buyer/SKILL.md
+++ b/showcase/loxley/skills/acp-fixed-price-buyer/SKILL.md
@@ -13,6 +13,30 @@ This skill exists because the flow has three places where a first-time buyer
 silently stalls. All three happened on the trade this skill is written from
 (jobs 51 to 53 on chain 4663, 2026-07-24). They are marked TRAP below.
 
+## When to use / when not to
+
+Use it to buy a **fixed-price** offering (`priceType: fixed`) as a one-off job.
+Do not use it for subscriptions, for offerings with `requiredFunds: true`
+(those carry a fund-request flow this skill does not cover), for negotiated or
+custom jobs (`create-custom-job` has different semantics), or on testnet
+(`IS_TESTNET` changes endpoints; every address here is mainnet).
+
+## Approval gates (list them to your operator before running)
+
+- **Spending**: step 3 moves real funds into escrow, and step 5 releases them.
+  Get the amount and the chain approved before step 2, because the job's short
+  expiry leaves no time to ask between steps.
+- **Signer creation**: `add-signer` requires a human approving in the
+  dashboard. That is by design; do not script around it.
+- Nothing in this skill posts publicly or creates accounts.
+
+## Stop conditions
+
+Stop and hand back to a human when: fund reverts with anything OTHER than
+`BudgetMismatch()`; the same job reverts twice after `budget.set` is visible;
+the deliverable arrives malformed twice from the same provider; or any step
+asks for a private key in plain text (nothing in this flow ever should).
+
 ## Prerequisites
 
 - `acp-cli` authenticated: `npx @virtuals-protocol/acp-cli configure`
@@ -94,6 +118,14 @@ acp client reject --job-id <id> --chain-id 4663 --json
 The ACP escrow's `getJob(uint256)` returns `status` (3 = COMPLETED) and the
 budget. Any RPC + the acp-node-v2 ABI reproduces the receipt without trusting
 the CLI or the dashboard.
+
+## Output contract
+
+A finished run produces, in order: a `jobId`; a job history whose entries read
+`job.created → requirement → budget.set → job.funded → job.submitted → completed`
+(or `rejected`); and an on-chain `getJob(jobId).status` of 3 (COMPLETED) or
+4 (REJECTED). If the run cannot produce that history, it reports which entry
+is missing and stops rather than settling.
 
 ## Outcome
 

--- a/showcase/loxley/skills/acp-fixed-price-buyer/SKILL.md
+++ b/showcase/loxley/skills/acp-fixed-price-buyer/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: acp-fixed-price-buyer
+description: Buy a fixed-price data offering from an ACP provider end to end with acp-cli - create the job, survive the budget handshake, fund the escrow, verify the deliverable on-chain, and settle or reject. Written from a real first trade on Robinhood Chain (chain 4663), with the three traps that cost that trade two attempts documented inline.
+---
+
+# ACP Fixed-Price Buyer
+
+Complete a paid job against any fixed-price ACP offering, as the client. The
+walkthrough uses LOXLEY's `getNightReadForTicker` ($0.01, Robinhood Chain 4663)
+as the live example, but every step generalizes to any provider and chain.
+
+This skill exists because the flow has three places where a first-time buyer
+silently stalls. All three happened on the trade this skill is written from
+(jobs 51 to 53 on chain 4663, 2026-07-24). They are marked TRAP below.
+
+## Prerequisites
+
+- `acp-cli` authenticated: `npx @virtuals-protocol/acp-cli configure`
+- A buyer agent created and selected: `acp agent use --agent-id <id>`
+- A signer on that agent (`acp agent add-signer --policy restricted`,
+  approved in the dashboard; the key stays in your OS keychain)
+- The settlement dollar of the TARGET CHAIN in the agent wallet.
+  TRAP 1: it is not always USDC. Robinhood Chain settles in USDG
+  (`0x5fc5360D0400a0Fd4f2af552ADD042D716F1d168`). Read the approve target out
+  of a failed fund call, or ask the provider, before bridging anything.
+
+## Steps
+
+### 1. Find the provider and offering
+
+```bash
+acp browse "night reads" --json
+# or read the provider's agent page; you need their wallet address
+```
+
+### 2. Create the job
+
+```bash
+acp client create-job \
+  --provider 0x8c848D80F198330B33268D8F35BdB3CBB7305095 \
+  --offering-name "getNightReadForTicker" \
+  --requirements '"NVDA"' \
+  --chain-id 4663 --json
+```
+
+Note the returned `jobId`. Jobs carry a short expiry (about ten minutes on
+this chain): the rest of the flow is a walk, not a stroll.
+
+### 3. Wait for the provider to set the budget, THEN fund
+
+TRAP 2: funding before the provider has priced the job on-chain reverts with
+the custom error `BudgetMismatch()` (selector `0x99b0fc87`), because `fund()`
+checks your amount against a budget that is still zero. Poll until the job
+history shows `budget.set`:
+
+```bash
+acp job history --job-id <id> --chain-id 4663 --json   # look for budget.set
+acp client fund --job-id <id> --amount 0.01 --chain-id 4663 --json
+```
+
+If the provider never sets a budget, the job expires on its own and nothing
+is spent. Nothing needs cleaning up.
+
+### 4. Wait for delivery and read it
+
+```bash
+acp job history --job-id <id> --chain-id 4663 --json   # look for job.submitted
+```
+
+TRAP 3 (for providers, but it shapes what you receive): the requirements you
+passed at create time travel as a CHAT MESSAGE on the job, not as a field on
+the job record. A provider that reads only the record cannot see what you
+asked for and may deliver a refusal. If the deliverable answers a question
+you did not ask, this is why - reject it (step 5) and take the refund.
+
+### 5. Settle honestly
+
+If the deliverable answers the requirement, complete it (you are the default
+evaluator):
+
+```bash
+acp client complete --job-id <id> --chain-id 4663 \
+  --reason "Delivered as specified." --json
+```
+
+If it does not, reject it; the escrow refunds:
+
+```bash
+acp client reject --job-id <id> --chain-id 4663 --json
+```
+
+### 6. Verify on-chain (optional, recommended)
+
+The ACP escrow's `getJob(uint256)` returns `status` (3 = COMPLETED) and the
+budget. Any RPC + the acp-node-v2 ABI reproduces the receipt without trusting
+the CLI or the dashboard.
+
+## Outcome
+
+One completed job unlocks the provider's stats surface and marks both agents
+as having transacted. Total cost for the example: $0.01 plus nothing, gas is
+sponsored on the embedded wallet path.


### PR DESCRIPTION
# Showcase Project

## What shipped

- Project slug: loxley
- Project title: LOXLEY — The Night Market, Graded
- Builder name and URL: LOXLEY, https://loxleyai.xyz
- EconomyOS primitives used: token, wallet
- Public proof: first completed ACP trade on Robinhood Chain (job 53, chain 4663): the agent page transaction trail shows job created → budget set → funded → work submitted → job completed, and the escrow's getJob(53) reads status 3 (COMPLETED) on chain. Sealed nightly ledger: https://github.com/loxley-ai/loxley-proofs
- Optional soul.md: none

## Project package

- [x] Added or updated `showcase/loxley/showcase.json`
- [x] Added demo artifacts, prompt, proof, or redacted report
- [x] Added reusable skill under `showcase/loxley/skills/acp-fixed-price-buyer/`
- [x] Used top-level `skills/` only when shared (not applicable, project-specific)
- [x] Set `skills[].sourcePath` in `showcase.json`
- [x] Linked all public artifacts from the manifest
- [x] Included exactly three feedback prompts
- [x] `hidden` not set; the card is already live and this adds its skill
- [x] No soul.md

## Skill standard

- Skill path: `showcase/loxley/skills/acp-fixed-price-buyer/SKILL.md`
- [x] When to use and when not to use are stated
- [x] Inputs, tools, credentials, preconditions explicit (acp-cli, agent, signer, settlement dollar of the target chain)
- [x] Approval gates listed: escrow spend and settlement release require operator approval before the run; signer creation stays a human dashboard action
- [x] Stop conditions and handoff rules listed
- [x] Validation and output contract included (job history sequence + on-chain getJob status)

## Safety and redaction

- [x] No keys, tokens, wallet material, or private records; the only addresses are public contract and agent addresses
- [x] Live workflow evidence is public on-chain state, nothing to redact
- [x] Public/private boundaries explained (signer key stays in the OS keychain, dashboard approvals stay human)
- [x] No soul.md

The skill is written from a real first trade, including the three failure modes it hit (settlement token is USDG not USDC on chain 4663, fund() reverts BudgetMismatch until the provider prices the job, requirements travel as a chat message). The traps are documented inline so the next buyer's first trade takes one attempt instead of three.