### PR TITLE
ci: bump actions off deprecated Node.js 20 runtime

### DIFF
--- a/.github/workflows/dispatch-showcase-sync.yml
+++ b/.github/workflows/dispatch-showcase-sync.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Trigger EconomyOS docs showcase sync
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ secrets.SHOWCASE_SYNC_TOKEN }}
           repository: Virtual-Protocol/whitepaper-economyOS

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "22"
 


### PR DESCRIPTION
GitHub Actions runners are forcing our Node 20 actions onto Node 24 and emitting a deprecation warning ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). This bumps every affected action to the current major, all of which declare `using: node24`.

| Action | Before | After |
| --- | --- | --- |
| `actions/checkout` | `v4` (node20) | `v7` (node24) |
| `actions/setup-node` | `v4` (node20) | `v7` (node24) |
| `peter-evans/repository-dispatch` | `v3` (node20) | `v4` (node24) |

`repository-dispatch@v3` was also on node20, so it needed the bump too.

### Breaking changes checked along the way

- **setup-node v5** added automatic dependency caching when `package.json` contains a `packageManager` field; **v6** narrowed that to npm only. No `package.json` in this repo declares `packageManager`, and there is no lockfile at the root, so auto-caching stays off and there is no "lock file is not found" failure to guard against. `package-manager-cache: false` is therefore unnecessary.
- **checkout v5** raised the minimum runner to v2.327.1 — satisfied by `ubuntu-latest`.
- **checkout v7** now refuses to check out fork PR code under `pull_request_target` / `workflow_run` unless `allow-unsafe-pr-checkout: true` is set. Neither workflow on `main` uses those triggers, so nothing here is affected.

### Verification

`typecheck.yml` runs the showcase validator, the install helper, the routing-utility checks, and the Claude Desktop packaging steps. A green run on this PR is the check.

### Follow-up: `showcase-pr-review.yml`

That workflow is **not on `main`** — it lives only on the unmerged branch `feat/showcase-pr-auto-review`, so it is out of scope for this PR and needs the same bump applied there.

Worth noting for whoever does it: it uses `pull_request_target` and deliberately checks out the base commit (`ref: github.event.pull_request.base.sha || github.ref`), never the PR head. That base-sha checkout **passes** checkout v7's new fork-PR guard — `assertSafePrCheckout` early-returns because the base SHA is not among the payload's `head.sha` / `merge_commit_sha` values and the ref does not match `refs/pull/*`. So the bump needs no `allow-unsafe-pr-checkout` opt-in, and v7 in fact enforces the security property that workflow was written to uphold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)