### PR TITLE
fix: secret scan flagged every on-chain proof artifact as a private key

### DIFF
--- a/scripts/showcase-review/gather.mjs
+++ b/scripts/showcase-review/gather.mjs
@@ -329,17 +329,45 @@ export async function check_urls(urls, { head_repo, head_sha, token } = {}) {
   return checks
 }
 
+// A bare 0x + 64 hex is NOT evidence of a private key. Transaction hashes, EAS
+// attestation and schema UIDs, block hashes, deliverable hashes and hex-encoded
+// strings are all exactly that shape — and they are the entire point of this repo, so
+// matching on shape alone flags every genuine proof artifact. (Measured on PR #95: six
+// hits, all of them attestation UIDs, tx hashes or a hex-encoded "Approved".)
+//
+// So require key-ish wording near the value, and stand down when the surrounding text
+// names a known-public identifier or the value sits inside a URL.
+const SECRET_CONTEXT = /(private[_\s-]?key|privkey|secret[_\s-]?key|seed[_\s-]?phrase|mnemonic)/i
+const PUBLIC_IDENTIFIER = /(tx|transaction|hash|uid|attestation|schema|block|deliverable|receipt|digest|commit|signature|proof|address|wallet)/i
+
+function looks_like_leaked_key(text, match) {
+  const before = text.slice(Math.max(0, match.index - 80), match.index)
+  const after = text.slice(match.index + match[0].length, match.index + match[0].length + 40)
+
+  // Inside a URL it is a public identifier by definition.
+  if (/https?:\/\/\S*$/.test(before)) return false
+  if (PUBLIC_IDENTIFIER.test(before) && !SECRET_CONTEXT.test(before)) return false
+  return SECRET_CONTEXT.test(before) || SECRET_CONTEXT.test(after)
+}
+
 export function scan_for_secrets(package_files) {
-  const patterns = [
-    ['raw private key', /0x[a-fA-F0-9]{64}/],
-    ['PRIVATE_KEY assignment', /PRIVATE_KEY\s*[=:]\s*\S+/],
-    ['mnemonic', /\bmnemonic\b\s*[=:]/i],
-  ]
   const hits = []
   for (const file of package_files) {
     if (typeof file.text !== 'string') continue
-    for (const [label, pattern] of patterns) {
-      if (pattern.test(file.text)) hits.push({ path: file.path, kind: label })
+
+    for (const match of file.text.matchAll(/0x[a-fA-F0-9]{64}/g)) {
+      if (looks_like_leaked_key(file.text, match)) {
+        hits.push({ path: file.path, kind: 'possible private key (64-hex next to key wording)' })
+        break
+      }
+    }
+
+    // These two are high-signal on their own: a hash is never introduced this way.
+    if (/PRIVATE_KEY\s*[=:]\s*["']?0x?[a-fA-F0-9]{32,}/i.test(file.text)) {
+      hits.push({ path: file.path, kind: 'PRIVATE_KEY assigned a key-shaped value' })
+    }
+    if (/\b(mnemonic|seed[_\s-]?phrase)\b\s*[=:]\s*["']?(\w+\s+){11,}/i.test(file.text)) {
+      hits.push({ path: file.path, kind: 'mnemonic / seed phrase assignment' })
     }
   }
   return hits

--- a/scripts/showcase-review/gemini.mjs
+++ b/scripts/showcase-review/gemini.mjs
@@ -109,6 +109,15 @@ ${url_lines}
 
 ## Secret scan hits
 ${secret_hits.length ? secret_hits.map((hit) => `- ${hit.path}: ${hit.kind}`).join('\n') : '- none'}
+NOTE: this scan is a crude keyword heuristic, NOT a verified finding. On-chain
+identifiers (transaction hashes, EAS attestation and schema UIDs, block and
+deliverable hashes, hex-encoded strings) share the shape of a private key and are the
+normal, expected content of this repo. Before mentioning a hit at all, look at the
+actual value in the file contents above and decide what it really is. If it is an
+identifier in a URL or labelled as a hash/UID/tx, say nothing about it. Only if a
+value is genuinely key-shaped AND presented as a credential should you raise it — and
+then ask the author to confirm rather than asserting a leak, and do not tell anyone to
+rewrite git history.
 
 ## Contributor file contents
 ${file_blocks || '[no text files read]'}`


### PR DESCRIPTION
## What happened

The first backfill dry run (`pr_numbers: all`, `dry_run: true`) had the reviewer tell PR #95:

> The biggest thing is that the secret scanner found what look like **raw private keys** in the `aiport-verifier` and `antfleet-pr-audit` packages. That's a hard blocker — those need to be removed from the files and maybe the git history before this can move forward.

**All six hits were false positives.** What they actually were:

| Value | Actually |
| --- | --- |
| `0x94fa44b1…` | EAS attestation UID, inside a public `easscan.org` URL |
| `0x740e289a…` | EAS schema UID |
| `0x82e3fd52…` | Basescan settlement **transaction hash** |
| `0xdb8b92ee…` | `deliverableHash` |
| `0x41707072…` | hex-encoded ASCII — the word "Approved" |

## Why

The pattern was `/0x[a-fA-F0-9]{64}/`. That is the shape of a private key *and* the shape of a transaction hash, attestation UID, block hash, or content hash — indistinguishable. Those artifacts are the entire point of a showcase submission, so matching on shape alone gives roughly a **100% false-positive rate on exactly the content this repo exists to collect**.

Caught only because the backfill was dry-run first. Posting it would have falsely accused a contributor of leaking a key.

## Fix

- Require key-ish wording (`private key`, `privkey`, `secret key`, `seed phrase`, `mnemonic`) near the value; stand down when the value is inside a URL or the surrounding text names a public identifier (`tx`, `hash`, `uid`, `attestation`, `schema`, `deliverable`, …).
- Tighten the `PRIVATE_KEY` / mnemonic patterns to require a key-shaped value, not any assignment.
- Tell the model this scan is an **unverified heuristic**: check the real value before mentioning it, ask the author to confirm rather than assert a leak, and never recommend rewriting git history.

## Verification

- PR #95's real file set → **0 hits** (was 6)
- Still caught: `PRIVATE_KEY=0x…`, a key introduced as "private key: 0x…", a 12-word mnemonic
- Stay silent: tx hashes, attestation UIDs, schema UIDs, `deliverableHash`, URL-embedded identifiers

## Merge this before posting any reviews

The backfill has only ever run in dry-run mode, so nothing was published. This should land before `dry_run: false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)