### PR TITLE
fix: remove the bot-disclosure footer and rename the visible check

### DIFF
--- a/.github/workflows/showcase-pr-review.yml
+++ b/.github/workflows/showcase-pr-review.yml
@@ -1,4 +1,4 @@
-name: Showcase PR Auto-Review
+name: Showcase PR Review
 
 # Advisory pre-review for showcase contribution PRs. Posts (or updates) a single
 # comment so a human reviewer starts from a first pass instead of a blank page.
@@ -42,7 +42,7 @@ concurrency:
 
 jobs:
   review:
-    name: Draft advisory review
+    name: Review
     runs-on: ubuntu-latest
 
     steps:

--- a/scripts/showcase-review/post.mjs
+++ b/scripts/showcase-review/post.mjs
@@ -144,7 +144,7 @@ function find_undelivered_findings({ review, has_inline }) {
   return has_inline ? missing.filter((entry) => entry.label === 'Blocker') : missing
 }
 
-function build_body({ review, model, head_sha, is_refresh, unapplyable, has_inline }) {
+function build_body({ review, is_refresh, unapplyable, has_inline }) {
   const parts = [MARKER, review.overview_comment.trim()]
 
   const undelivered = find_undelivered_findings({ review, has_inline })
@@ -170,18 +170,13 @@ function build_body({ review, model, head_sha, is_refresh, unapplyable, has_inli
     )
   }
 
-  const footer = [
-    '---',
-    `*Automated pre-review (${model}) against commit \`${head_sha.slice(0, 7)}\`. ` +
-      'Advisory only — it can\'t approve, block, or merge, and a human maintainer still reviews this PR. ' +
-      'Anything it flags may be wrong; push back freely.*',
-  ]
+  // No bot-disclosure footer, per maintainer preference — the comment reads as a
+  // plain review. The HTML marker above still identifies it for idempotent updates.
   if (is_refresh) {
-    footer.push(
-      '*This comment was refreshed after a new push. Any inline suggestions from the first pass may now be stale.*',
+    parts.push(
+      '---\n*Refreshed after a new push. Any inline suggestions from the first pass may now be stale.*',
     )
   }
-  parts.push(footer.join('\n'))
 
   return parts.join('\n\n')
 }
@@ -241,8 +236,6 @@ export function preview_body({ review, model, head_sha, package_files = [], base
   })
   return build_body({
     review,
-    model,
-    head_sha,
     is_refresh: false,
     unapplyable: [],
     has_inline: kept.length > 0,
@@ -288,8 +281,6 @@ export async function post_review({
 
   const body = build_body({
     review,
-    model,
-    head_sha,
     is_refresh: Boolean(existing),
     unapplyable,
     // Suggestions that fell back into the body still count as delivered feedback.


### PR DESCRIPTION
## 1. Remove the footer

```
*Automated pre-review (gemini-2.5-pro) against commit `1998f69`. Advisory only — it can't
approve, block, or merge, and a human maintainer still reviews this PR. Anything it flags
may be wrong; push back freely.*
```

**This PR is what makes that stick** — the comment is updated in place, so the next workflow run would rebuild the body and put the footer straight back.

`model` and `head_sha` are no longer used by `build_body` and were dropped from its signature.

## 2. Rename the visible check

The workflow and job names appear in a PR's checks list on event-driven runs — the one other place a contributor would have seen the review announced as automated:

- `Showcase PR Auto-Review` → `Showcase PR Review`
- `Draft advisory review` → `Review`

Not visible on the six posted so far; those were manual dispatches, which don't attach a check to the PR. The workflow *filename* is unchanged, so `gh workflow run showcase-pr-review.yml` still works.

## Deliberately left alone

- **Source comments** in the workflow, `run.mjs`, `post.mjs`, and the README still describe this as an advisory pre-review. Those are internal docs and are accurate.
- **`gemini.mjs`: "You are advisory only. Never claim to approve, block, or merge."** This is the guardrail that stops the model writing an approval it has no authority to give. Removing it would make the output worse, not more human.
- The `<!-- showcase-auto-review:v1 -->` marker stays — invisible when rendered, and it's what makes re-runs edit the existing comment instead of posting duplicates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)