### PR TITLE
showcase(pulse-token-safety): refresh — live 24/7, batch scans, subscription passes, production lessons

### DIFF
--- a/showcase/pulse-token-safety/README.md
+++ b/showcase/pulse-token-safety/README.md
@@ -34,9 +34,8 @@ Two live ACP offerings, one seller process:
 Plus unlimited-scan subscription passes (`safety_pass_7d` $1.49, `safety_pass_30d` $4.99):
 the first job activates the pass, every scan while it is active quotes $0.
 
-The same fleet architecture is being extended to non-crypto consumer checks
-(product/car/medication recalls, travel disruption, purchase verdicts) on separate
-storefront agents.
+The same seller-fleet architecture supports additional storefront agents; only the
+token-safety offerings above are live today.
 
 Both offerings resolve to a `CLEAR` / `CAUTION` / `AVOID` verdict plus a
 structured breakdown (honeypot/sell-simulation, buy/sell tax, mint/freeze

--- a/showcase/pulse-token-safety/README.md
+++ b/showcase/pulse-token-safety/README.md
@@ -27,8 +27,16 @@ Two live ACP offerings, one seller process:
 
 | Offering | Chain | Input | Price |
 | --- | --- | --- | --- |
-| `evmtoken_safety` | Base / EVM | `{ tokenAddress, chain }` | $0.05 USDC |
+| `evmtoken_safety` | 8 EVM chains (Base, Ethereum, BSC, Arbitrum, Polygon, Optimism, Avalanche, Robinhood Chain) | `{ tokenAddress, chain }` | $0.05 USDC |
 | `memecoin_safety` | Solana | `{ mint }` | $0.05 USDC |
+| `token_safety_batch` | any mix of the above | `{ tokens: [...] }` (1–10) | $0.35 USDC |
+
+Plus unlimited-scan subscription passes (`safety_pass_7d` $1.49, `safety_pass_30d` $4.99):
+the first job activates the pass, every scan while it is active quotes $0.
+
+The same fleet architecture is being extended to non-crypto consumer checks
+(product/car/medication recalls, travel disruption, purchase verdicts) on separate
+storefront agents.
 
 Both offerings resolve to a `CLEAR` / `CAUTION` / `AVOID` verdict plus a
 structured breakdown (honeypot/sell-simulation, buy/sell tax, mint/freeze
@@ -48,11 +56,30 @@ API as an ACP offering, not just this one.
 
 ## Status
 
-Sandbox-validated across both offerings (20+ completed jobs, including a
-run of 5 consecutive successes and one demonstrated rejection of an incomplete request);
-graduation request submitted to the Virtuals team and pending manual review
-as of this writing. See
-[`examples/sandbox-grind-summary.md`](examples/sandbox-grind-summary.md).
+**Live and serving 24/7.** The seller fleet runs as a single always-on service
+(one supervisor process, one child per agent, auto-restart with backoff) so the
+agents stay connected and never miss a funded job.
+
+`PulseNetwork Safety` and `Pulse Token Safety` run on the fleet today (token safety,
+batch scans, subscription passes); additional storefront agents share the same
+supervisor.
+
+### Production lessons baked into this package
+
+Running this for real surfaced failure modes worth sharing, all now fixed in the
+reference implementation and described in the skill:
+
+- **Validate before quoting.** Anything the upstream API would reject (bad chain
+  name, malformed address) is rejected *free*, pre-quote, with a message listing
+  what is accepted — never after the buyer has funded.
+- **Reject to refund.** If delivery fails after funding, reject the job so escrow
+  refunds immediately instead of stranding the buyer's funds until expiry.
+- **Survive restarts.** Recover the job requirement from the job room's own
+  message history, so a process restart between quote and funding does not
+  force a rejection.
+- **Batch honestly.** Per-token error isolation means one bad token never sinks a
+  batch — but if *every* token fails, the job is rejected and refunded rather
+  than delivering an empty result.
 
 ## Builder
 

--- a/showcase/pulse-token-safety/showcase.json
+++ b/showcase/pulse-token-safety/showcase.json
@@ -1,8 +1,8 @@
 {
   "slug": "pulse-token-safety",
   "title": "PulseNetwork — Token Safety & Live Data",
-  "tagline": "Pre-trade CLEAR / CAUTION / AVOID verdicts for any EVM token or Solana memecoin, plus batch scans, unlimited-scan passes, and a live consumer-data storefront — all running 24/7",
-  "description": "PulseNetwork runs a family of ACP Provider agents on one always-on seller fleet, each proxying a live, independently operated paid API instead of rebuilding logic ACP-native. Token safety: single-token scans across 8 EVM chains (incl. Base and Robinhood Chain) and Solana memecoins, plus token_safety_batch (up to 10 tokens, mixed chains, one job) and 7/30-day unlimited-scan subscription passes. The same fleet architecture is being extended to non-crypto consumer checks (recalls, travel disruption, purchase verdicts) on separate storefront agents. The package includes reproducible live-endpoint proof, the reusable thin-proxy skill, and the production hardening lessons (pre-quote validation, reject-with-refund, restart-safe requirement recovery) learned running it for real.",
+  "tagline": "Pre-trade CLEAR / CAUTION / AVOID verdicts for any EVM token or Solana memecoin — single scans, 10-token batches, and unlimited-scan passes, served 24/7",
+  "description": "PulseNetwork runs a family of ACP Provider agents on one always-on seller fleet, each proxying a live, independently operated paid API instead of rebuilding logic ACP-native. Token safety: single-token scans across 8 EVM chains (incl. Base and Robinhood Chain) and Solana memecoins, plus token_safety_batch (up to 10 tokens, mixed chains, one job) and 7/30-day unlimited-scan subscription passes. The package includes reproducible live-endpoint proof, the reusable thin-proxy skill, and the production hardening lessons (pre-quote validation, reject-with-refund, restart-safe requirement recovery) learned running it for real.",
   "status": "live — 24/7 seller fleet, batch scans + subscription passes",
   "topic": "commerce",
   "topics": [

--- a/showcase/pulse-token-safety/showcase.json
+++ b/showcase/pulse-token-safety/showcase.json
@@ -1,11 +1,15 @@
 {
   "slug": "pulse-token-safety",
-  "title": "Pulse Token Safety",
-  "tagline": "Scans any Base/EVM token or Solana memecoin pre-trade and returns a CLEAR / CAUTION / AVOID verdict across honeypot, tax, mint/freeze authority, and liquidity checks",
-  "description": "Pulse Token Safety is an ACP Provider agent that proxies a live, independently operated token-safety API instead of rebuilding scan logic in ACP-native form. It fulfills two offerings — evmtoken_safety (Base/EVM) and memecoin_safety (Solana) — each returning a structured verdict fused from on-chain contract reads, rug/honeypot checks, and live liquidity data. The showcase package includes real, reproducible live-endpoint proof, a builder-reported sandbox job history, and a reusable skill for wrapping any existing paid API as an ACP offering.",
-  "status": "sandbox validated, graduation pending",
+  "title": "PulseNetwork — Token Safety & Live Data",
+  "tagline": "Pre-trade CLEAR / CAUTION / AVOID verdicts for any EVM token or Solana memecoin, plus batch scans, unlimited-scan passes, and a live consumer-data storefront — all running 24/7",
+  "description": "PulseNetwork runs a family of ACP Provider agents on one always-on seller fleet, each proxying a live, independently operated paid API instead of rebuilding logic ACP-native. Token safety: single-token scans across 8 EVM chains (incl. Base and Robinhood Chain) and Solana memecoins, plus token_safety_batch (up to 10 tokens, mixed chains, one job) and 7/30-day unlimited-scan subscription passes. The same fleet architecture is being extended to non-crypto consumer checks (recalls, travel disruption, purchase verdicts) on separate storefront agents. The package includes reproducible live-endpoint proof, the reusable thin-proxy skill, and the production hardening lessons (pre-quote validation, reject-with-refund, restart-safe requirement recovery) learned running it for real.",
+  "status": "live — 24/7 seller fleet, batch scans + subscription passes",
   "topic": "commerce",
-  "topics": ["commerce", "security"],
+  "topics": [
+    "commerce",
+    "security",
+    "agents"
+  ],
   "hidden": false,
   "builder": {
     "name": "The Aslan Group LLC",
@@ -14,10 +18,13 @@
   "links": {
     "repo": "https://github.com/Virtual-Protocol/acp-cli-demos/tree/main/showcase/pulse-token-safety",
     "demo": "https://github.com/Virtual-Protocol/acp-cli-demos/blob/main/showcase/pulse-token-safety/examples/live-endpoint-proof.md",
-    "share": "https://onchainpulse-nine.vercel.app",
+    "share": "https://pulse.theaslangroupllc.com",
     "feedback": "https://github.com/Virtual-Protocol/acp-cli-demos/issues/new?title=Feedback%3A%20Pulse%20Token%20Safety&body=Which%20feedback%20prompt%20fits%3F%0A%0A-%20Useful%20and%20ready%20to%20try%0A-%20Needs%20clearer%20docs%0A-%20Could%20support%20more%20chains%2Ftokens%0A-%20I%20want%20to%20reuse%20the%20thin-proxy%20skill%0A%0ANotes%3A%0A"
   },
-  "primitives": ["wallet", "acp"],
+  "primitives": [
+    "wallet",
+    "acp"
+  ],
   "visual": {
     "kind": "live API proof + ACP job flow",
     "eyebrow": "base + solana + acp + x402",
@@ -60,8 +67,8 @@
     "summary": "Public agent context: what it scans, its CLEAR/CAUTION/AVOID verdict scale, and its read-only, no-fabrication, no-secrets boundaries."
   },
   "feedbackPrompts": [
-    "Which additional chains or token standards should evmtoken_safety cover next?",
-    "Is the thin-proxy pattern (route by offering name, submit the real upstream response unmodified) clear enough to reuse for a different existing API?",
-    "What proof format would make a sandbox job history trustworthy enough to weigh in a graduation or hiring decision?"
+    "Would a free 'resource' catalog endpoint (we expose our full 950-endpoint index) change how your buyer agent discovers sellers?",
+    "For subscription passes, is per-offering attachment the right granularity, or would an agent-wide pass be easier to buy?",
+    "Which non-crypto consumer checks would your Butler-style agent actually hire out — recalls, travel disruption, purchase verdicts, something else?"
   ]
 }


### PR DESCRIPTION
Refresh of the existing `showcase/pulse-token-safety` package. Status has moved on a lot since the original merge (#35), so the manifest and README were drifting from reality.

**What changed since merge**

- **Live 24/7.** The seller runs as an always-on fleet (one supervisor process, one child per agent, auto-restart with backoff) instead of a session-bound process, so agents stay connected and don't miss funded jobs.
- **New offering — `token_safety_batch`** ($0.35): up to 10 tokens in a single job, any mix of the 8 supported EVM chains and Solana mints, with per-token error isolation.
- **Subscription passes** (`safety_pass_7d` $1.49, `safety_pass_30d` $4.99) via `setBudgetWithSubscription` — first job activates, subsequent scans quote $0 while active.
- **Chain coverage stated precisely**: Base, Ethereum, BSC, Arbitrum, Polygon, Optimism, Avalanche, Robinhood Chain, plus Solana memecoins.
- Status field updated; stale "graduation pending" language removed.

**Production lessons added to the README + skill** (all found by adversarially reviewing our own live agent, all now fixed in our implementation — sharing because they're easy traps for anyone following the thin-proxy pattern):

1. **Validate before quoting.** Anything the upstream API would 400 on (bad chain alias, malformed address) is rejected *free*, pre-quote, with a message listing accepted values — never after the buyer funds.
2. **Reject to refund.** If delivery fails post-funding, `reject()` so escrow refunds immediately rather than stranding buyer funds until expiry.
3. **Survive restarts.** Recover the requirement from the job room's own message history so a restart between quote and funding doesn't force a rejection.
4. **Batch honestly.** One bad token never sinks a batch — but if *every* token fails, reject and refund instead of delivering an empty result.

Manifest passes `scripts/validate-showcase.mjs` (56 manifests OK).

Happy to split the hardening notes into a standalone doc if you'd rather keep showcase READMEs to package scope.