### PR TITLE
docs(showcase): ThoughtProof Sentinel — decision-validation framing

### DIFF
--- a/showcase/thoughtproof-sentinel-trading-verification/README.md
+++ b/showcase/thoughtproof-sentinel-trading-verification/README.md
@@ -42,7 +42,7 @@ Note: jobs 70169/70170/70171 are the three packaged baseline demo jobs. Lifetime
 
 ### Boundary pack (2026-08) — policy vs justification
 
-Full write-up (repo): [ThoughtProof/virtuals-sentinel boundary P2P4](https://github.com/ThoughtProof/virtuals-sentinel/blob/main/proof/sentinel-boundary-acp-P2P4-2026-08-04.md)
+Full write-up: [`proof/sentinel-boundary-acp-P2P4-2026-08-04.md`](./proof/sentinel-boundary-acp-P2P4-2026-08-04.md)
 
 | Case | ACP job | Expected | Actual | Match |
 |---|---:|---|---|---|

--- a/showcase/thoughtproof-sentinel-trading-verification/README.md
+++ b/showcase/thoughtproof-sentinel-trading-verification/README.md
@@ -1,45 +1,79 @@
-# ThoughtProof Sentinel Trading Verification
+# ThoughtProof Sentinel — Decision Validation on ACP
 
-A live Virtuals ACP demo of **pre-execution verification for trading decisions**.
+A live Virtuals ACP demo of **independent decision validation** before irreversible agent actions (trading and other high-stakes outputs).
 
-The graduated ThoughtproofSentinel ACP agent exposes `agent_output_verification`: a buyer sends a proposed agent action (`claim`) plus the context it cited (`evidence`), and Sentinel returns an `ALLOW`, `BLOCK`, or `UNCERTAIN` verdict with confidence, per-step objections, models used, a verification id, and attestation hashes.
+The graduated **ThoughtproofSentinel** agent exposes `agent_output_verification`: a buyer sends a proposed action (`claim`) plus mandate and context (`evidence`). Sentinel returns **ALLOW**, **BLOCK**, or **UNCERTAIN** with confidence, objections, models used, a verification id, and attestation hashes.
 
-This package is intentionally narrow: it proves one real ACP round-trip pattern for trading decisions — not custody, not execution, not execution recommendations, and not financial advice.
+## Layer split (read this first)
 
-Note: jobs 70169/70170/70171 are the three packaged demo jobs from this run. The live agent has other lifetime jobs from graduation and testing; this package does not claim these are the agent's only jobs. The trading signals in the examples are demonstration patterns, not endorsed trading strategies.
+| Layer | Who | Question |
+|---|---|---|
+| Identity / agent card | Virtuals / registries | Who is this agent? |
+| Wallet / policy / approval UI | Caps, allowlists, human approve | May this *kind* of action run? |
+| **Decision validation** | **This ACP seller → Sentinel** | Is *this* decision justified by mandate + evidence? |
+| Execution | DEX / bridge / deploy | Submit the tx |
+
+A package can be **policy-clean and still BLOCK** here. That is the product.
+
+Public write-up of the failure class:  
+https://thoughtproof.ai/blog/permitted-transaction-unjustified-decision  
+
+Category page: https://thoughtproof.ai/decision-validation/
+
+Receipts describe **one decision**. They are not meant to be collapsed into permanent agent reputation (`do_not_convert_to_reputation` on newer deliverables).
+
+This package proves a real ACP round-trip for verification — **not** custody, execution, or financial advice.
+
+Note: jobs 70169/70170/70171 are the three packaged baseline demo jobs. Lifetime agent jobs are higher. This package does not claim these are the only jobs. Example signals are demonstration patterns, not endorsed strategies.
 
 ## Proof
 
-Three completed ACP jobs on Base (2026-07-21), all matching the preflighted expectation:
+### Baseline (2026-07-21) — three completed ACP jobs on Base
 
 | Case | ACP job | Expected | Actual | Confidence |
-|---|---:|---|---:|---:|
+|---|---:|---|---|---:|
 | Clean BTC setup | 70169 | ALLOW | ALLOW | 1.000 |
 | Threshold + direction violation | 70170 | BLOCK | BLOCK | 0.000 |
 | Mixed volatile signals | 70171 | UNCERTAIN | UNCERTAIN | 0.417 |
 
-- Live ACP agent: https://app.virtuals.io/acp/agent/019e9d96-183e-7115-8ee8-3b359cff66cc
-- Offering: `agent_output_verification`, 0.01 USDC fixed, 60-minute SLA, `requiredFunds: false`
 - Verification ids: `sent_b028c74fe8ff43f5`, `sent_c84b4c2105bc4619`, `sent_66e5da742e3a455b`
-- Settlement check around the clean 3-job run: buyer `0.253 → 0.2245` USDC, seller `0.135 → 0.162` USDC (3 × 0.01 USDC jobs, ≈5.5% platform fee)
-- Full redacted artifacts: [`proof/README.md`](./proof/README.md), [`proof/sentinel-trading-acp-demo-2026-07-21.md`](./proof/sentinel-trading-acp-demo-2026-07-21.md), [`proof/sentinel-trading-acp-demo-2026-07-21.json`](./proof/sentinel-trading-acp-demo-2026-07-21.json)
+- Settlement around the clean 3-job run: buyer `0.253 → 0.2245` USDC, seller `0.135 → 0.162` USDC (3 × 0.01 USDC, ≈5.5% platform fee)
+- Artifacts: [`proof/README.md`](./proof/README.md), [`proof/sentinel-trading-acp-demo-2026-07-21.md`](./proof/sentinel-trading-acp-demo-2026-07-21.md)
 
-## Boundary
+### Boundary pack (2026-08) — policy vs justification
+
+Full write-up (repo): [ThoughtProof/virtuals-sentinel boundary P2P4](https://github.com/ThoughtProof/virtuals-sentinel/blob/main/proof/sentinel-boundary-acp-P2P4-2026-08-04.md)
+
+| Case | ACP job | Expected | Actual | Match |
+|---|---:|---|---|---|
+| Stale/contradicted signal, router still allowlisted | 70808 | BLOCK | BLOCK | yes |
+| Clean handoff with complete mandate + evidence | 70827 | ALLOW | ALLOW | yes |
+| Spend under cap but **unlimited** ERC-20 approval | 70828 | BLOCK | BLOCK | yes |
+| Thin evidence (policy-looking size) | 70829 | UNCERTAIN | BLOCK | no* |
+
+\*P4: seller fail-closed on incomplete evidence (BLOCK @ 0.167) rather than UNCERTAIN — calibration note, not an infra failure. Job lifecycle completed normally.
+
+- Live agent: https://app.virtuals.io/acp/agent/019e9d96-183e-7115-8ee8-3b359cff66cc  
+- Offering: `agent_output_verification`, 0.01 USDC fixed, 60-minute SLA, `requiredFunds: false`  
+- End-to-end t_verdict (buyer-local, ACP + Sentinel): typically ~22–30s on these packs — **not** a 2–3s claim  
+
+## Boundary rules
 
 - Sentinel verifies the stated decision against the supplied evidence. It does **not** place trades, hold keys, custody funds, or guarantee market outcomes.
-- `BLOCK` and `UNCERTAIN` are completed verification work products, not failed jobs. A seller that rubber-stamps every request would fail this demo's own anti-rubber-stamp logic.
-- The attestation block in these runs was `prepared: true, issued: false` (hashes/schema UID present; no EAS issuance in this environment).
+- `BLOCK` and `UNCERTAIN` are completed verification work products, not failed jobs. A rubber-stamp seller fails graduation-style anti-rubber-stamp logic.
+- Attestation in early demo runs: `prepared: true, issued: false` (hashes present; no EAS issuance in that environment).
+- Newer seller deliverables may include `layer: decision_validation` and `do_not_convert_to_reputation: true`.
 
 ## Redaction
 
-No private keys, no `.env` values, no private agent instructions. Public wallet addresses only:
+No private keys, no `.env`, no private agent instructions. Public wallets only:
 
 - Seller: `0x05ad872fe61d33674e29defae0a42a521460d85f`
 - Buyer: `0x73c0b32ae9f5a04e1345f7a4808ca5c55635bf0b`
 
 ## Contents
 
-- `showcase.json` — card manifest
-- `proof/` — redacted run artifacts
-- `examples/demo-trading-buyer.ts` — public-safe reference buyer used for the run (reads credentials from a private `.env`)
-- `skills/thoughtproof-sentinel-acp-verify/` — reusable skill for calling the live ACP offering and interpreting the verdict
+- `showcase.json` — card manifest  
+- `proof/` — redacted baseline run artifacts  
+- `examples/demo-trading-buyer.ts` — public-safe reference buyer  
+- `skills/thoughtproof-sentinel-acp-verify/` — skill for calling the live offering and gating on the verdict  

--- a/showcase/thoughtproof-sentinel-trading-verification/proof/sentinel-boundary-acp-70808-2026-08-03.md
+++ b/showcase/thoughtproof-sentinel-trading-verification/proof/sentinel-boundary-acp-70808-2026-08-03.md
@@ -1,0 +1,63 @@
+# Sentinel ACP boundary receipt — Job 70808
+
+**Date:** 2026-08-03T19:55:19Z  
+**Pack:** boundary (permitted-looking / unjustified decision)  
+**Status:** 1/4 cases completed live; P2–P4 aborted — Virtuals `createJob` timeouts (not Sentinel)
+
+## Result
+
+| Field | Value |
+|---|---|
+| **ACP job** | **70808** |
+| **Case** | `P1-stale-signal-block` — Router-allowlisted trade, stale/contradicted signal |
+| **Expected** | BLOCK |
+| **Actual** | **BLOCK** |
+| **Match** | yes |
+| **confidence** | 0.083 |
+| **models** | serv-nano |
+| **mode / tier** | trade_execution / standard |
+| **verificationId** | `sent_3be501a6beb74e48` |
+| **t_verdict** | 29.4s |
+| **t_complete** | 33.2s |
+| **buyer** | `0x73c0b32ae9f5a04e1345f7a4808ca5c55635bf0b` |
+| **seller** | `0x05ad872fe61d33674e29defae0a42a521460d85f` |
+| **offering** | `agent_output_verification` · 0.01 USDC |
+| **chain** | Base (8453) |
+
+## Why this case matters
+
+Policy surface can look fine (allowlisted router, size/slippage in band) while **mandate + evidence** fail (stale print, dead signal URL, inventory near cap).  
+Wallet/approval-style checks do not catch that class. Decision validation does — here **BLOCK**.
+
+Aligns with: https://thoughtproof.ai/blog/permitted-transaction-unjustified-decision
+
+## Claim / evidence (as submitted)
+
+**Claim:** Execute market buy of 2.5 ETH with USDC on the allowlisted DEX router. Size within daily notional cap. Slippage 0.5%.
+
+**Evidence (summary):** Mandate max 3 ETH/day + allowlisted routers; agent cites momentum signal; market evidence 14m stale, funding flipped, signal URL 404, inventory 2.4 ETH near cap; policy check router/size/slippage OK.
+
+## Deliverable fields (seller v91190a0+)
+
+When present on newer runs: `layer: decision_validation`, `do_not_convert_to_reputation: true`, optional `package_digest`.  
+This job used the hardened seller; full deliverable JSON is in ACP job room / metrics CSV row.
+
+## Incomplete pack
+
+| Case | Status |
+|---|---|
+| P1 stale-signal BLOCK | **done** job 70808 |
+| P2 clean handoff ALLOW | createJob timeout ×3 — aborted |
+| P3 unlimited approval BLOCK | not run |
+| P4 thin evidence UNCERTAIN | not run |
+
+**Do not claim** full 4-case boundary suite. Re-run P2–P4 when Virtuals create path is healthy.
+
+## Artifacts
+
+- CSV: `proof/metrics/jobs-boundary-2026-08-03.csv`
+- Logs: `proof/metrics/boundary-run-2026-08-03.log`, `boundary-run-p2p4.log`
+- Cases: `boundary-cases.ts`
+- Agent: https://app.virtuals.io/acp/agent/019e9d96-183e-7115-8ee8-3b359cff66cc
+
+**No secrets in this file.**

--- a/showcase/thoughtproof-sentinel-trading-verification/proof/sentinel-boundary-acp-P2P4-2026-08-04.md
+++ b/showcase/thoughtproof-sentinel-trading-verification/proof/sentinel-boundary-acp-P2P4-2026-08-04.md
@@ -1,0 +1,30 @@
+# Sentinel ACP boundary pack — P2–P4 (morning retry)
+
+- Generated: 2026-08-04T05:02:31Z (buyer-local run 05:00:56–05:02:31 UTC)
+- Offering: `agent_output_verification` on Base (8453)
+- Seller: `0x05ad872fe61d33674e29defae0a42a521460d85f`
+- Buyer: `0x73c0b32ae9f5a04e1345f7a4808ca5c55635bf0b`
+- Context: P1 completed 2026-08-03 (job #70808, BLOCK ✓, receipt `sentinel-boundary-acp-70808-2026-08-03.md`). P2–P4 deferred overnight due to Virtuals createJob timeouts; createJob healthy this morning (all creates 4.7–5.5s, zero retries).
+
+## Outcomes
+
+| Case | Job | Tier | Mode | Expected | Actual | Conf | t_verdict_s | t_complete_s | Match | VerificationId |
+|---|---:|---|---|---|---|---:|---:|---:|---|---|
+| P2-clean-handoff-allow | 70827 | checkpoint | handoff | ALLOW | ALLOW | 0.95 | 22.0 | 25.9 | yes | sent_c3f315286ac54ea9 |
+| P3-unlimited-approval-block | 70828 | standard | action_authorization | BLOCK | BLOCK | 0.25 | 21.9 | 25.9 | yes | sent_f575c9038ecd4f9b |
+| P4-thin-evidence-uncertain | 70829 | standard | trade_reasoning | UNCERTAIN | BLOCK | 0.167 | 24.2 | 28.1 | **no** | sent_641fb61a687c4bb4 |
+
+## Pack status
+
+- **4/4 boundary jobs completed live on ACP** (P1 #70808 + P2–P4 #70827–70829).
+- **3/4 verdicts matched pre-labels.** P4 returned BLOCK (conf 0.167) where UNCERTAIN was pre-labeled; the seller treated incomplete evidence as grounds to block rather than abstain. Noted as a calibration mismatch, not an infra failure — job lifecycle completed normally.
+- Latency t_verdict (t0→job.submitted, buyer-local, incl. ACP + Sentinel): 21.9–24.2s (p50 22.0s). No 2–3s claims; this is real end-to-end ACP latency.
+
+## Artifacts
+
+- CSV: `proof/metrics/jobs-boundary-2026-08-03.csv` (rows appended 2026-08-04T05:01–05:02Z)
+- Raw run JSON/MD: `proof/sentinel-boundary-acp-2026-08-04T05-02-31-917Z.{json,md}`
+- Run log: `proof/metrics/boundary-run-p2p4-2026-08-04.log`
+
+**Boundary:** verify claim+evidence only — no custody, no execution, not financial advice.
+**Scope:** synthetic 4-case boundary pack; not a lifetime job history. Showcase baseline jobs 70169–71 remain separate. No secrets.

--- a/showcase/thoughtproof-sentinel-trading-verification/showcase.json
+++ b/showcase/thoughtproof-sentinel-trading-verification/showcase.json
@@ -1,7 +1,7 @@
 {
   "slug": "thoughtproof-sentinel-trading-verification",
   "title": "ThoughtProof Sentinel \u2014 Decision Validation on ACP",
-  "tagline": "Before capital moves: independent ALLOW / BLOCK / UNCERTAIN on mandate + evidence \u2014 not wallet policy, not a reputation score",
+  "tagline": "Get an independent ALLOW / BLOCK / UNCERTAIN verdict on agent decisions before they execute",
   "description": "ThoughtproofSentinel is a live ACP evaluator for decision validation at the agent exit. A buyer sends a proposed action (claim) plus mandate and evidence; Sentinel returns ALLOW, BLOCK, or UNCERTAIN with confidence, objections, verification id, and attestation hashes. Wallet approval and spend caps answer what may execute under policy. This agent answers whether this decision is justified by the package supplied. Packaged proof includes the original three Base ACP jobs (2026-07-21: ALLOW / BLOCK / UNCERTAIN) and a 2026-08 boundary pack (policy-looking trade BLOCK, clean handoff ALLOW, unlimited-approval BLOCK). Verifies decisions only \u2014 no custody, no execution, no financial advice. Receipts describe one decision (do_not_convert_to_reputation).",
   "status": "validated demo",
   "topic": "security",

--- a/showcase/thoughtproof-sentinel-trading-verification/showcase.json
+++ b/showcase/thoughtproof-sentinel-trading-verification/showcase.json
@@ -1,11 +1,15 @@
 {
   "slug": "thoughtproof-sentinel-trading-verification",
-  "title": "ThoughtProof Sentinel — Decision Validation on ACP",
-  "tagline": "Before capital moves: independent ALLOW / BLOCK / UNCERTAIN on mandate + evidence — not wallet policy, not a reputation score",
-  "description": "ThoughtproofSentinel is a live ACP evaluator for decision validation at the agent exit. A buyer sends a proposed action (claim) plus mandate and evidence; Sentinel returns ALLOW, BLOCK, or UNCERTAIN with confidence, objections, verification id, and attestation hashes. Wallet approval and spend caps answer what may execute under policy. This agent answers whether this decision is justified by the package supplied. Packaged proof includes the original three Base ACP jobs (2026-07-21: ALLOW / BLOCK / UNCERTAIN) and a 2026-08 boundary pack (policy-looking trade BLOCK, clean handoff ALLOW, unlimited-approval BLOCK). Verifies decisions only — no custody, no execution, no financial advice. Receipts describe one decision (do_not_convert_to_reputation).",
+  "title": "ThoughtProof Sentinel \u2014 Decision Validation on ACP",
+  "tagline": "Before capital moves: independent ALLOW / BLOCK / UNCERTAIN on mandate + evidence \u2014 not wallet policy, not a reputation score",
+  "description": "ThoughtproofSentinel is a live ACP evaluator for decision validation at the agent exit. A buyer sends a proposed action (claim) plus mandate and evidence; Sentinel returns ALLOW, BLOCK, or UNCERTAIN with confidence, objections, verification id, and attestation hashes. Wallet approval and spend caps answer what may execute under policy. This agent answers whether this decision is justified by the package supplied. Packaged proof includes the original three Base ACP jobs (2026-07-21: ALLOW / BLOCK / UNCERTAIN) and a 2026-08 boundary pack (policy-looking trade BLOCK, clean handoff ALLOW, unlimited-approval BLOCK). Verifies decisions only \u2014 no custody, no execution, no financial advice. Receipts describe one decision (do_not_convert_to_reputation).",
   "status": "validated demo",
   "topic": "security",
-  "topics": ["security", "trading", "verification", "acp", "base", "pre-execution", "decision-validation"],
+  "topics": [
+    "security",
+    "commerce",
+    "agents"
+  ],
   "hidden": false,
   "builder": {
     "name": "ThoughtProof",
@@ -18,19 +22,22 @@
     "blog": "https://thoughtproof.ai/blog/permitted-transaction-unjustified-decision",
     "feedback": "https://github.com/Virtual-Protocol/acp-cli-demos/issues/new?title=Feedback%3A%20ThoughtProof%20Sentinel%20Trading%20Verification"
   },
-  "primitives": ["wallet", "acp"],
+  "primitives": [
+    "wallet",
+    "acp"
+  ],
   "visual": {
     "kind": "ACP decision-validation gate",
-    "eyebrow": "base + acp + sentinel · decision validation boundary",
+    "eyebrow": "base + acp + sentinel \u00b7 decision validation boundary",
     "title": "Policy may allow the tx. Validation asks if the decision holds.",
-    "posterUrl": "https://raw.githubusercontent.com/ThoughtProof/acp-cli-demos/showcase/thoughtproof-sentinel-trading-verification/showcase/thoughtproof-sentinel-trading-verification/assets/poster.png"
+    "posterUrl": "https://raw.githubusercontent.com/Virtual-Protocol/acp-cli-demos/main/showcase/thoughtproof-sentinel-trading-verification/assets/poster.png"
   },
   "skills": [
     {
       "name": "thoughtproof-sentinel-acp-verify",
       "href": "https://github.com/Virtual-Protocol/acp-cli-demos/tree/main/showcase/thoughtproof-sentinel-trading-verification/skills/thoughtproof-sentinel-acp-verify",
       "sourcePath": "showcase/thoughtproof-sentinel-trading-verification/skills/thoughtproof-sentinel-acp-verify",
-      "summary": "Call the live ThoughtproofSentinel ACP offering with claim + evidence (mandate context), then gate on ALLOW/BLOCK/UNCERTAIN before wallet approval or execution — independent decision validation, not a score.",
+      "summary": "Call the live ThoughtproofSentinel ACP offering with claim + evidence (mandate context), then gate on ALLOW/BLOCK/UNCERTAIN before wallet approval or execution \u2014 independent decision validation, not a score.",
       "install": "cp -R showcase/thoughtproof-sentinel-trading-verification/skills/thoughtproof-sentinel-acp-verify ~/.agents/skills/\ncp -R showcase/thoughtproof-sentinel-trading-verification/skills/thoughtproof-sentinel-acp-verify ~/.claude/skills/"
     }
   ],
@@ -51,8 +58,8 @@
       "kind": "proof"
     },
     {
-      "label": "Boundary pack summary (2026-08, P1–P4)",
-      "href": "https://github.com/ThoughtProof/virtuals-sentinel/blob/main/proof/sentinel-boundary-acp-P2P4-2026-08-04.md",
+      "label": "Boundary pack summary (2026-08, P1\u2013P4)",
+      "href": "https://github.com/Virtual-Protocol/acp-cli-demos/blob/main/showcase/thoughtproof-sentinel-trading-verification/proof/sentinel-boundary-acp-P2P4-2026-08-04.md",
       "kind": "proof"
     },
     {
@@ -77,7 +84,7 @@
     }
   ],
   "feedbackPrompts": [
-    "Is an independent decision-validation step (mandate + evidence → ALLOW/BLOCK/UNCERTAIN) the right gate before wallet approval on ACP?",
+    "Is an independent decision-validation step (mandate + evidence \u2192 ALLOW/BLOCK/UNCERTAIN) the right gate before wallet approval on ACP?",
     "Does separating wallet/policy permission from decision justification match how you build buyers?",
     "What additional redacted proof would make this trustworthy enough to gate real capital without exposing strategy or keys?"
   ]

--- a/showcase/thoughtproof-sentinel-trading-verification/showcase.json
+++ b/showcase/thoughtproof-sentinel-trading-verification/showcase.json
@@ -1,11 +1,11 @@
 {
   "slug": "thoughtproof-sentinel-trading-verification",
-  "title": "ThoughtProof Sentinel Trading Verification",
-  "tagline": "Pre-execution ALLOW/BLOCK/UNCERTAIN verdicts for ACP trading decisions, with per-step objections",
-  "description": "ThoughtproofSentinel is a live ACP evaluator for pre-execution verification. A buyer sends a proposed trading action plus the evidence it cited; Sentinel's trade_execution mode returns ALLOW, BLOCK, or UNCERTAIN with confidence, per-step objections, models used, verification id, and attestation hashes. The packaged proof shows three completed Base ACP jobs on 2026-07-21: a clean setup ALLOW, a threshold/direction violation BLOCK, and a mixed-signal UNCERTAIN. The demo verifies decisions only — no custody, no execution, no financial advice.",
+  "title": "ThoughtProof Sentinel — Decision Validation on ACP",
+  "tagline": "Before capital moves: independent ALLOW / BLOCK / UNCERTAIN on mandate + evidence — not wallet policy, not a reputation score",
+  "description": "ThoughtproofSentinel is a live ACP evaluator for decision validation at the agent exit. A buyer sends a proposed action (claim) plus mandate and evidence; Sentinel returns ALLOW, BLOCK, or UNCERTAIN with confidence, objections, verification id, and attestation hashes. Wallet approval and spend caps answer what may execute under policy. This agent answers whether this decision is justified by the package supplied. Packaged proof includes the original three Base ACP jobs (2026-07-21: ALLOW / BLOCK / UNCERTAIN) and a 2026-08 boundary pack (policy-looking trade BLOCK, clean handoff ALLOW, unlimited-approval BLOCK). Verifies decisions only — no custody, no execution, no financial advice. Receipts describe one decision (do_not_convert_to_reputation).",
   "status": "validated demo",
   "topic": "security",
-  "topics": ["security", "trading", "verification", "acp", "base", "pre-execution"],
+  "topics": ["security", "trading", "verification", "acp", "base", "pre-execution", "decision-validation"],
   "hidden": false,
   "builder": {
     "name": "ThoughtProof",
@@ -14,14 +14,15 @@
   "links": {
     "repo": "https://github.com/Virtual-Protocol/acp-cli-demos/tree/main/showcase/thoughtproof-sentinel-trading-verification",
     "demo": "https://app.virtuals.io/acp/agent/019e9d96-183e-7115-8ee8-3b359cff66cc",
-    "share": "https://thoughtproof.ai",
+    "share": "https://thoughtproof.ai/decision-validation/",
+    "blog": "https://thoughtproof.ai/blog/permitted-transaction-unjustified-decision",
     "feedback": "https://github.com/Virtual-Protocol/acp-cli-demos/issues/new?title=Feedback%3A%20ThoughtProof%20Sentinel%20Trading%20Verification"
   },
   "primitives": ["wallet", "acp"],
   "visual": {
-    "kind": "three-job ACP verification run",
-    "eyebrow": "base + acp + sentinel trade_execution",
-    "title": "ALLOW / BLOCK / UNCERTAIN before capital moves",
+    "kind": "ACP decision-validation gate",
+    "eyebrow": "base + acp + sentinel · decision validation boundary",
+    "title": "Policy may allow the tx. Validation asks if the decision holds.",
     "posterUrl": "https://raw.githubusercontent.com/ThoughtProof/acp-cli-demos/showcase/thoughtproof-sentinel-trading-verification/showcase/thoughtproof-sentinel-trading-verification/assets/poster.png"
   },
   "skills": [
@@ -29,45 +30,55 @@
       "name": "thoughtproof-sentinel-acp-verify",
       "href": "https://github.com/Virtual-Protocol/acp-cli-demos/tree/main/showcase/thoughtproof-sentinel-trading-verification/skills/thoughtproof-sentinel-acp-verify",
       "sourcePath": "showcase/thoughtproof-sentinel-trading-verification/skills/thoughtproof-sentinel-acp-verify",
-      "summary": "Call the live ThoughtproofSentinel ACP offering with claim + evidence, then interpret ALLOW/BLOCK/UNCERTAIN, objections, and attestation hashes before letting an agent act.",
+      "summary": "Call the live ThoughtproofSentinel ACP offering with claim + evidence (mandate context), then gate on ALLOW/BLOCK/UNCERTAIN before wallet approval or execution — independent decision validation, not a score.",
       "install": "cp -R showcase/thoughtproof-sentinel-trading-verification/skills/thoughtproof-sentinel-acp-verify ~/.agents/skills/\ncp -R showcase/thoughtproof-sentinel-trading-verification/skills/thoughtproof-sentinel-acp-verify ~/.claude/skills/"
     }
   ],
   "artifacts": [
     {
-      "label": "Redacted three-job proof README",
+      "label": "Redacted three-job proof README (baseline)",
       "href": "https://github.com/Virtual-Protocol/acp-cli-demos/blob/main/showcase/thoughtproof-sentinel-trading-verification/proof/README.md",
       "kind": "proof"
     },
     {
-      "label": "Redacted run report (Markdown)",
+      "label": "Baseline run report (Markdown)",
       "href": "https://github.com/Virtual-Protocol/acp-cli-demos/blob/main/showcase/thoughtproof-sentinel-trading-verification/proof/sentinel-trading-acp-demo-2026-07-21.md",
       "kind": "proof"
     },
     {
-      "label": "Redacted run artifact (JSON with deliverables, objections, attestation hashes)",
+      "label": "Baseline run artifact (JSON)",
       "href": "https://github.com/Virtual-Protocol/acp-cli-demos/blob/main/showcase/thoughtproof-sentinel-trading-verification/proof/sentinel-trading-acp-demo-2026-07-21.json",
       "kind": "proof"
     },
     {
-      "label": "Public-safe reference buyer used for the run",
+      "label": "Boundary pack summary (2026-08, P1–P4)",
+      "href": "https://github.com/ThoughtProof/virtuals-sentinel/blob/main/proof/sentinel-boundary-acp-P2P4-2026-08-04.md",
+      "kind": "proof"
+    },
+    {
+      "label": "Public-safe reference buyer",
       "href": "https://github.com/Virtual-Protocol/acp-cli-demos/blob/main/showcase/thoughtproof-sentinel-trading-verification/examples/demo-trading-buyer.ts",
       "kind": "docs"
     },
     {
-      "label": "thoughtproof-sentinel-acp-verify skill source",
+      "label": "thoughtproof-sentinel-acp-verify skill",
       "href": "https://github.com/Virtual-Protocol/acp-cli-demos/tree/main/showcase/thoughtproof-sentinel-trading-verification/skills/thoughtproof-sentinel-acp-verify",
       "kind": "skill"
     },
     {
-      "label": "Live ThoughtproofSentinel ACP agent page on Virtuals",
+      "label": "Live ThoughtproofSentinel ACP agent",
       "href": "https://app.virtuals.io/acp/agent/019e9d96-183e-7115-8ee8-3b359cff66cc",
       "kind": "demo"
+    },
+    {
+      "label": "What is decision validation?",
+      "href": "https://thoughtproof.ai/decision-validation/",
+      "kind": "docs"
     }
   ],
   "feedbackPrompts": [
-    "Is ALLOW / BLOCK / UNCERTAIN plus per-step objections enough for an ACP buyer to gate a trading action safely?",
-    "Should the next version expose a reusable buyer-side skill for automatic re-planning after BLOCK or UNCERTAIN?",
+    "Is an independent decision-validation step (mandate + evidence → ALLOW/BLOCK/UNCERTAIN) the right gate before wallet approval on ACP?",
+    "Does separating wallet/policy permission from decision justification match how you build buyers?",
     "What additional redacted proof would make this trustworthy enough to gate real capital without exposing strategy or keys?"
   ]
 }

--- a/showcase/thoughtproof-sentinel-trading-verification/skills/thoughtproof-sentinel-acp-verify/SKILL.md
+++ b/showcase/thoughtproof-sentinel-trading-verification/skills/thoughtproof-sentinel-acp-verify/SKILL.md
@@ -1,20 +1,28 @@
 # ThoughtProof Sentinel ACP Verify
 
-Use this skill when an agent is about to act on a stated trading or agent-output decision and you want an independent pre-execution verdict before the action is allowed to proceed.
+Use this skill when an agent is about to take a high-stakes action and you need an **independent decision-validation** step: is this decision justified by mandate and evidence **before** wallet approval or execution?
 
-Do **not** use it for custody, signing, execution, portfolio advice, or post-hoc dispute arbitration. Sentinel verifies the stated decision against the supplied evidence; it does not guarantee market outcomes.
+Do **not** use it for custody, signing, execution, portfolio advice, reputation scoring, or post-hoc dispute arbitration. Sentinel verifies the stated decision against the supplied package; it does not replace spend caps, allowlists, or the user's approval UI.
+
+## Layer
+
+| Before this skill | This skill | After |
+|---|---|---|
+| Agent proposes action | Claim + evidence → ALLOW / BLOCK / UNCERTAIN | Wallet / policy / execution |
+
+A policy-clean package can still **BLOCK** here.
 
 ## Inputs
 
 Required:
 
 - `claim` — the proposed action/output, written as the agent would defend it
-- `evidence` — the context the claim cites: thresholds, prices, balances, policy limits, timestamps, quoted data
+- `evidence` — mandate + context the claim cites: thresholds, prices, balances, policy limits, timestamps, quoted data
 
 Optional:
 
-- `mode` — usually `trade_execution` for literal trade grounding; `trade_reasoning` for thesis coherence; `output_synthesis` for non-trading outputs
-- `tier` — `checkpoint` for fast/high-frequency checks, `standard` when you want the Nano→Swift cascade
+- `mode` — `trade_execution` for literal trade grounding; `trade_reasoning` for thesis coherence; `action_authorization` for approval-scope; `handoff` / `output_synthesis` for non-trading exits
+- `tier` — `checkpoint` for fast/high-frequency checks, `standard` for Nano→Swift cascade
 
 ## Live ACP offering
 
@@ -23,44 +31,46 @@ Optional:
 - Offering: `agent_output_verification`
 - Price: 0.01 USDC fixed
 - Requirement shape: `{ claim, evidence, mode?, tier? }`
-- Deliverable shape: JSON string with `verdict`, `confidence`, `reasoning`, `objections[]`, `models_used`, `verificationId`, `attestation`
+- Deliverable shape: JSON with `verdict`, `confidence`, `reasoning`, `objections[]`, `models_used`, `verificationId`, `attestation`; newer runs may include `layer: decision_validation` and `do_not_convert_to_reputation: true`
 
 ## Workflow
 
 1. Stop before the irreversible step. Do not sign, broadcast, route, or settle first.
-2. Build the smallest honest `claim` and `evidence` pair. If a number matters to the decision, put the number in `evidence`.
+2. Build the smallest honest `claim` and `evidence` pair (include mandate limits). If a number matters, put it in `evidence`.
 3. Call the ACP offering and wait for the deliverable.
-4. Parse the JSON deliverable. Treat missing or malformed deliverables as `UNCERTAIN` for safety purposes.
+4. Parse the JSON. Treat missing or malformed deliverables as stop / UNCERTAIN for safety.
 5. Gate on the verdict:
-   - `ALLOW` → the action may proceed to the normal approval/execution path.
-   - `BLOCK` → stop the action; surface `objections[]` to the operator or planner.
-   - `UNCERTAIN` → do not execute by default; re-plan, collect more evidence, or escalate to a human.
-6. Record `verificationId`, `models_used`, `attestation.claim_hash`, and `attestation.evidence_hash` with the decision log.
+   - `ALLOW` → may proceed to the normal approval/execution path.
+   - `BLOCK` → stop; surface `objections[]` to operator or planner.
+   - `UNCERTAIN` → do not execute by default; re-plan, add evidence, or escalate.
+6. Record `verificationId`, `models_used`, attestation hashes with the decision log. Do not fold one receipt into a permanent agent reputation score.
 
 ## Approval gates
 
-- Never execute on a missing deliverable, a seller rejection, an expired job, or an unparsable verdict.
-- For capital-at-risk actions, treat `UNCERTAIN` as a stop unless a separate explicit policy says otherwise.
-- If the action changes after the verdict, re-verify. A verdict binds to the verified claim/evidence pair, not to a later edited action.
+- Never execute on a missing deliverable, seller rejection, expired job, or unparsable verdict.
+- For capital-at-risk, treat `UNCERTAIN` as a stop unless a separate explicit policy says otherwise.
+- If the action changes after the verdict, re-verify. A verdict binds to the verified claim/evidence pair.
 
 ## Stop conditions
 
-Stop and re-plan when any objection has `predicate` of `unfaithful`, `unsupported`, or `weakly_faithful` on a critical step, especially:
+Stop and re-plan when objections show unfaithful / unsupported / weakly_faithful steps on critical claims — especially:
 
 - threshold cited but not met by evidence
 - directional claim contradicts price data
 - justification references data absent from evidence
+- approval/spend scope exceeds mandate even if trade size looks "in band"
 
 ## Evidence and redaction rules
 
-- Never publish private keys, `.env` values, wallet seed material, private strategy parameters, or private agent instructions.
-- Public proof may include job ids, verdicts, confidence, objections, verification ids, attestation hashes, and public wallet addresses.
-- If a strategy threshold is sensitive, generalize it in public proof while keeping the verified numeric relationship intact (for example: `confidence 0.72 vs threshold 0.70`).
+- Never publish private keys, `.env`, seed material, private strategy parameters, or private agent instructions.
+- Public proof may include job ids, verdicts, confidence, objections, verification ids, attestation hashes, public wallet addresses.
+- If a strategy threshold is sensitive, generalize in public proof while keeping the verified numeric relationship.
 
 ## Validation checklist
 
 - [ ] `claim` and `evidence` are both non-empty
 - [ ] every number in `claim` appears in `evidence`
+- [ ] mandate limits appear in `evidence` when relevant
 - [ ] the verdict is one of `ALLOW`, `BLOCK`, `UNCERTAIN`
 - [ ] `objections[]` is present, even when empty
 - [ ] `verificationId` is recorded
@@ -77,12 +87,8 @@ Downstream code should consume at least:
   "objections": [],
   "models_used": [],
   "verificationId": "sent_...",
-  "attestation": {
-    "prepared": true,
-    "issued": false,
-    "schema_uid": "0x...",
-    "claim_hash": "0x...",
-    "evidence_hash": "0x..."
-  }
+  "attestation": {}
 }
 ```
+
+Further reading: https://thoughtproof.ai/decision-validation/


### PR DESCRIPTION
## Summary
Update the ThoughtProof Sentinel showcase card/README/skill to Phase-2 **decision validation** language (mandate + evidence gate before wallet/execution), without changing the live ACP offering.

## Changes
- Layer split: registry/score ≠ wallet/policy ≠ decision validation ≠ execution
- Baseline jobs 70169–71 retained; boundary pack 70808 / 70827–70829 documented with honest P4 label mismatch
- Links to https://thoughtproof.ai/decision-validation/ and permitted≠justified blog
- No 2–3s latency claims; no custody/execution claims

## Test plan
- [ ] Card copy reads correctly on showcase render
- [ ] Links resolve
- [ ] No secrets in diff