### PR TITLE
fix: add URL validation in run-transfer.mjs

### DIFF
--- a/showcase/compass-guarded-transfer/scripts/run-transfer.mjs
+++ b/showcase/compass-guarded-transfer/scripts/run-transfer.mjs
@@ -42,7 +42,11 @@ export function normalizeInput(input) {
   if (!Number.isFinite(amountUsd) || amountUsd < 0) stop("amountUsd policy input must be finite");
   const lamports = solToLamports(input.amountSol);
   if (lamports <= 0 || lamports > MAX_LAMPORTS) stop("amount must be greater than 0 and at most 0.001 SOL");
-  if (typeof input.compassUrl !== "string" || !input.compassUrl.startsWith("https://")) stop("Compass HTTPS URL is required");
+  let compassParsed;
+  try { compassParsed = new URL(input.compassUrl); } catch { stop("Compass HTTPS URL is required"); }
+  if (compassParsed.protocol !== "https:") stop("Compass HTTPS URL is required");
+  const compassHost = compassParsed.hostname;
+  if (/^(localhost|.*\.local)$/i.test(compassHost) || /^(127\.|10\.|192\.168\.|172\.(1[6-9]|2\d|3[01])\.|169\.254\.|0\.)/.test(compassHost) || compassHost === "[::1]") stop("Compass URL hostname is not allowed");
   return { recipient: input.recipient, amountSol: String(input.amountSol), lamports, amountUsd, cluster: "devnet", compassUrl: input.compassUrl.replace(/\/$/, ""), apiKey: input.apiKey };
 }
 


### PR DESCRIPTION
## Summary
Fix high severity security issue in `showcase/compass-guarded-transfer/scripts/run-transfer.mjs`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-002 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-002` |
| **File** | `showcase/compass-guarded-transfer/scripts/run-transfer.mjs:35` |
| **Assessment** | Likely exploitable |
| **CWE** | CWE-918 |

**Description**: The normalizeInput function validates some input fields but fails to properly validate the compassUrl parameter. While it checks that compassUrl starts with 'https://', it does not validate the URL format comprehensively or prevent SSRF (Server-Side Request Forgery) attacks. The function accepts any HTTPS URL and passes it directly to the verify() function at line 48, which makes an HTTP POST request to that URL. An attacker can provide a malicious URL pointing to internal services or cloud metadata endpoints.

## Evidence

**Exploitation scenario**: An attacker provides a malicious compassUrl like 'https://169.254.169.254/latest/meta-data/' (AWS metadata endpoint) or 'https://localhost:8080/admin' (internal service).

**Scanner confirmation**: multi_agent_ai rule `V-002` flagged this pattern.

## Threat Model Context

This is a local CLI tool - exploitation requires the attacker to control command-line arguments or input files.

## Changes
- `showcase/compass-guarded-transfer/scripts/run-transfer.mjs`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

## Security Invariant
> **Property**: The security boundary is maintained under adversarial input

<details>
<summary>Regression test</summary>

```javascript
import { normalizeInput } from '../showcase/compass-guarded-transfer/scripts/run-transfer.mjs';

describe("normalizeInput must reject SSRF-vulnerable compassUrl values", () => {
  const payloads = [
    // Exploit case: internal service URL
    { compassUrl: 'https://169.254.169.254/latest/meta-data/', recipient: '11111111111111111111111111111111', amountSol: '0.0001', amountUsdPolicyInput: '0.01', confirmed: 'yes', cluster: 'devnet', apiKey: 'test' },
    // Boundary case: malformed HTTPS URL
    { compassUrl: 'https://', recipient: '11111111111111111111111111111111', amountSol: '0.0001', amountUsdPolicyInput: '0.01', confirmed: 'yes', cluster: 'devnet', apiKey: 'test' },
    // Valid input (should pass)
    { compassUrl: 'https://compass.example.com/verify', recipient: '11111111111111111111111111111111', amountSol: '0.0001', amountUsdPolicyInput: '0.01', confirmed: 'yes', cluster: 'devnet', apiKey: 'test' }
  ];

  test.each(payloads)("rejects adversarial input: %s", (payload) => {
    if (payload.compassUrl === 'https://compass.example.com/verify') {
      // Valid case should normalize successfully
      const result = normalizeInput(payload);
      expect(result.compassUrl).toBe('https://compass.example.com/verify');
    } else {
      // Adversarial cases must throw
      expect(() => normalizeInput(payload)).toThrow();
    }
  });
});
```

</details>

This test guards against regressions — it's useful independent of the code change above.

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
