### PR TITLE
Fix stale base checkout in Showcase PR review

### DIFF
--- a/.github/workflows/showcase-pr-review.yml
+++ b/.github/workflows/showcase-pr-review.yml
@@ -46,13 +46,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      # Base commit only. Never `ref: pull_request.head.sha` here — that would put
-      # contributor-controlled code in a job that holds secrets and write access.
-      # A manual backfill has no PR payload, so it checks out the default branch.
+      # Trusted base-branch commit only. `github.sha` is the base branch tip selected
+      # for this workflow run. Do not use `pull_request.base.sha`: it can stay pinned
+      # to a commit from before the review scripts existed on long-lived PRs. Never
+      # use `pull_request.head.sha` here — that would execute contributor-controlled
+      # code in a job that holds secrets and write access.
       - name: Checkout base commit
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.base.sha || github.ref }}
+          ref: ${{ github.sha }}
           persist-credentials: false
 
       - name: Setup Node


### PR DESCRIPTION
## Summary

- checkout the trusted workflow-run SHA for Showcase PR reviews
- avoid long-lived PRs resolving to a base commit that predates the review scripts
- preserve the pull_request_target security boundary by never checking out contributor code

## Validation

- actionlint .github/workflows/showcase-pr-review.yml
- git diff --check
- node --check scripts/showcase-review/run.mjs

## Context

PR #97 remained pinned to base SHA 911b5e8, which predates scripts/showcase-review/run.mjs. Re-running its historical workflow therefore failed immediately in Review and post.